### PR TITLE
fix: expose deep research output errors

### DIFF
--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -67,6 +67,10 @@ PARENT_REPORT_CONTEXT_PATH = "/shared/parent_report_context.json"
 AGENT_DIR = Path(__file__).parent
 
 
+class WorkflowOutputError(RuntimeError):
+    """Raised when the deep-research workflow does not produce a final report."""
+
+
 class DeepResearcherAgent:
     """
     Deep research agent using deepagents library for multi-phase workflow.
@@ -367,7 +371,7 @@ class DeepResearcherAgent:
                     generated_answer=generated_answer,
                 )
             if final_message is None:
-                raise RuntimeError("writer_output_not_committed")
+                raise WorkflowOutputError("writer-agent did not produce a final Markdown answer")
 
             # Post-process: verify citations against source registry
             citation_registry = None

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -2161,12 +2161,13 @@ class TestFinalMarkdownExtraction:
             return_value=mock_agent,
         ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+            from aiq_agent.agents.deep_researcher.agent import WorkflowOutputError
 
             agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
             agent.source_registry_middleware.registry.add(SourceEntry(url="https://example.com"))
 
             state = DeepResearchAgentState(messages=[HumanMessage(content="Write a report")])
-            with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
+            with pytest.raises(WorkflowOutputError, match="writer-agent did not produce a final Markdown answer"):
                 await agent.run(state)
 
     @pytest.mark.asyncio
@@ -2191,12 +2192,13 @@ class TestFinalMarkdownExtraction:
             return_value=mock_agent,
         ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+            from aiq_agent.agents.deep_researcher.agent import WorkflowOutputError
 
             agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
             agent.source_registry_middleware.registry.add(SourceEntry(url="https://example.com"))
 
             state = DeepResearchAgentState(messages=[HumanMessage(content="Original query")])
-            with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
+            with pytest.raises(WorkflowOutputError, match="writer-agent did not produce a final Markdown answer"):
                 await agent.run(state)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Replaces the generic `ValueError` raised when the deep-research writer does not produce a final report with `WorkflowOutputError`.

## Root cause

Callers could not distinguish a normal workflow-output failure from unrelated validation or programming errors because the failure used a generic exception type.

## Changes

- Add `WorkflowOutputError`, a dedicated runtime exception for missing final deep-research output.
- Raise it when neither the writer output file nor a valid inline report is available.
- Update the regression test to verify the dedicated exception is raised.

## Validation

- `uv run pytest tests/aiq_agent/agents/deep_researcher/test_agent.py --no-header -q` (45 passed)
- `uv run ruff check src/aiq_agent/agents/deep_researcher/agent.py tests/aiq_agent/agents/deep_researcher/test_agent.py`
- `uv run ruff format --check src/aiq_agent/agents/deep_researcher/agent.py tests/aiq_agent/agents/deep_researcher/test_agent.py`

Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when a deep-research workflow fails to produce its final report.

* **Tests**
  * Updated workflow validation to confirm the more specific error is raised when report output is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->