### PR TITLE
fix(skills): update skills card

### DIFF
--- a/skills/aiq-deploy/SKILL.md
+++ b/skills/aiq-deploy/SKILL.md
@@ -26,8 +26,7 @@ allowed-tools: Read Bash
 
 ## When to Use This Skill
 
-Use this skill to get a local or self-hosted NVIDIA AI-Q Blueprint server running and verified for use by
-`aiq-research`.
+Use this skill to get a local or self-hosted NVIDIA AI-Q Blueprint server running and verified for use by `aiq-research`.
 
 This skill owns setup, deployment, operational checks, troubleshooting, and shutdown. It does not run deep
 research itself. After deployment is healthy, hand off the verified server URL to `aiq-research`.

--- a/skills/aiq-research/SKILL.md
+++ b/skills/aiq-research/SKILL.md
@@ -34,8 +34,7 @@ allowed-tools: Read Bash
 
 ## When to Use This Skill
 
-Use this skill to call a locally running NVIDIA AI-Q Blueprint server through the helper script at
-`scripts/aiq.py`.
+Use this skill to call a locally running NVIDIA AI-Q Blueprint server through the helper script at `scripts/aiq.py`.
 
 Use this skill for research-shaped requests, including:
 


### PR DESCRIPTION
#### Overview
No-op PR to trigger nvskills

<!-- Describe the change and why it is needed. -->

#### DCO sign-off for the squash commit

<!--
The RAPIDS auto-merger copies this PR description into the generated squash
commit. GitHub may author that commit with a different email than your local
commits. Replace the placeholder below with the exact commit email configured
for your GitHub account. If you keep your email private, copy the
`@users.noreply.github.com` address shown at https://github.com/settings/emails.

If your local/work email differs from your GitHub commit email, you may include
both sign-offs. DCO passes when one sign-off exactly matches the generated
squash commit author:

Signed-off-by: Full Name <work.email@example.com>
Signed-off-by <AjayThorve@users.noreply.github.com>

Keep the angle brackets around the email address. They are part of the required
DCO format: `Signed-off-by: Full Name <email@example.com>`.

Do not delete the sign-off line, leave the placeholder unchanged, or remove the
angle brackets.
-->

Signed-off-by Ajay Thorve <AjayThorve@users.noreply.github.com>

#### Validation

<!-- List the exact commands, workflows, screenshots, or manual checks used. -->

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

<!-- Point to the most important file, test, or design decision. -->

#### Related Issues

<!-- Use Closes / Fixes / Resolves / Relates to when applicable. -->

- Relates to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AIQ Deploy “When to Use This Skill” guidance to clarify it doesn’t perform deep research itself, and that after the deployed server is healthy, it becomes the entry point for infrastructure activities before AIQ Research starts.
  * Reflowed the first sentence in AIQ Research “When to Use This Skill” to improve readability of the local NVIDIA AI-Q Blueprint server instruction via `scripts/aiq.py` (no other guidance content changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->