### PR TITLE
fix(research): improve empty-source outcomes and artifact docs

### DIFF
--- a/ci/markdown-link-check-config.json
+++ b/ci/markdown-link-check-config.json
@@ -35,6 +35,9 @@
         },
         {
             "pattern": "^https?://huggingface\\.co/spaces/muset-ai/DeepResearch-Bench-Leaderboard$"
+        },
+        {
+            "pattern": "^https://you\\.com/docs/api-reference/contents/?$"
         }
     ],
     "replacementPatterns": [

--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -107,9 +107,8 @@ functions:
 AI-Q validates the public skill collection names (`research`, `synthesis`) and resolves them to DeepAgents source paths internally. When skills are configured, AI-Q mounts the configured built-in skill collections into the DeepAgents virtual filesystem. When the sandbox ref is present, DeepAgents `execute` calls run in the configured provider. Modal creates a fresh sandbox named for the job.
 
 In the reference async API flow, artifact capture uses the job database configured by
-`general.front_end.db_url` (`NAT_JOB_STORE_DB_URL`) for metadata. Without that job-scoped database URL, as in a direct
-`nat run`, Modal execution still works but durable capture remains inactive. Artifact bytes use SQL BLOB storage in the
-job database by default. For production, use S3-compatible object storage by setting `AIQ_ARTIFACT_BLOB_PROVIDER=s3`,
+`general.front_end.db_url` (`NAT_JOB_STORE_DB_URL`) for metadata. Artifact bytes use SQL BLOB storage in the job database
+by default. For production, use S3-compatible object storage by setting `AIQ_ARTIFACT_BLOB_PROVIDER=s3`,
 `AIQ_ARTIFACT_S3_BUCKET`, and the standard AWS credentials; set `AIQ_ARTIFACT_S3_ENDPOINT_URL` for MinIO or another
 compatible service. See [Production Artifact Storage](../../deployment/production.md#artifact-storage) for all options.
 
@@ -120,7 +119,14 @@ deletes the sandbox at terminal cleanup. Attaching to an existing shared
 sandbox is available only through explicit debug settings and is not
 job-isolated.
 
-## Run AI-Q
+## Run Synchronously with `nat run` (Non-Persistent)
+
+```{warning}
+`nat run` is a synchronous, single-run command. It does not create an async job record or connect the workflow to the
+job-scoped artifact store. The final report is returned normally, and `/shared/` files can contribute to that report
+during the run, but run state, `/shared/` content, and sandbox-generated files cannot be retrieved through the job or
+artifact APIs after the command finishes.
+```
 
 ```bash
 dotenv -f deploy/.env run .venv/bin/nat run \
@@ -128,7 +134,17 @@ dotenv -f deploy/.env run .venv/bin/nat run \
   --input "Compare the top 10 publicly traded semiconductor companies by 2024 revenue. Build a markdown table with revenue, YoY growth, market cap, and gross margin. Then rank them and compute summary statistics. Use the data analysis tool for all calculations."
 ```
 
-For API or UI testing:
+Use this mode to try the workflow when you only need its returned report. Do not use it when you need durable job state
+or separately retrievable charts, CSVs, notebooks, or other generated files.
+
+## Run with `nat serve` for Persistent Jobs and Artifacts
+
+To retain job information and retrieve supported generated files after a run, start the async API with `nat serve`.
+The configured `NAT_JOB_STORE_DB_URL` supplies the required job-scoped store. The reference config defaults to a local
+SQLite database; production deployments should configure PostgreSQL and appropriate artifact blob storage.
+For trusted local development, set `REQUIRE_AUTH=false` in `deploy/.env`; the commands below omit credentials on that
+basis. When `REQUIRE_AUTH=true`, these job routes require authentication, so configure authentication and add the same
+`Authorization: Bearer $AIQ_TOKEN` header to every `curl` command below.
 
 ```bash
 dotenv -f deploy/.env run .venv/bin/nat serve \
@@ -137,7 +153,37 @@ dotenv -f deploy/.env run .venv/bin/nat serve \
   --port 8000
 ```
 
-Then submit a deep research request through the AI-Q API or UI.
+In another terminal, submit a deep research request with a known job ID. Custom job IDs must be unique, so change this
+value before repeating the example against the same job store:
+
+```bash
+curl -X POST http://localhost:8000/v1/jobs/async/submit \
+  -H "Content-Type: application/json" \
+  -d '{
+    "job_id": "skills-sandbox-example",
+    "agent_type": "deep_researcher",
+    "input": "Compare the top 10 publicly traded semiconductor companies by 2024 revenue. Build a markdown table and a CSV with revenue, YoY growth, market cap, and gross margin. Then rank them and compute summary statistics. Use the data analysis tool for all calculations."
+  }'
+```
+
+Check the job until its status is either `success` or `failure`. If it reaches `failure`, inspect the response's `error`
+field for the actionable failure message:
+
+```bash
+curl http://localhost:8000/v1/jobs/async/job/skills-sandbox-example
+```
+
+List its captured artifacts, then use an `artifact_id` from the response to download one:
+
+```bash
+curl http://localhost:8000/v1/jobs/async/job/skills-sandbox-example/artifacts
+curl -OJ http://localhost:8000/v1/jobs/async/job/skills-sandbox-example/artifacts/{artifact_id}/content
+```
+
+Artifact capture is best-effort and limited to the configured file types and size. Stored artifacts are retrievable
+rather than permanent: server-wide retention cleanup can remove an artifact independently of the job's expiry. For the
+complete API contract, authentication guidance, and retention behavior, see
+[Durable Sandbox Artifacts](../../integration/rest-api.md#durable-sandbox-artifacts).
 
 ## Example Queries
 
@@ -230,8 +276,7 @@ No config change is required for additional built-in skills inside an enabled co
 - Text artifacts that need to survive for the report should be written through DeepAgents filesystem tools to `/shared/...`.
 - `/shared/` is a virtual DeepAgents filesystem path. Use `ls`, `read_file`, `write_file`, and `edit_file` for `/shared/`; do not inspect `/shared/` with shell commands through `execute`.
 - The sandbox is configured with `network: blocked`, so research should happen through AI-Q search tools, not from sandbox code.
-- The reference profile enables durable sandbox artifact capture, which requires the async API's job-scoped artifact
-  store. Successful `execute` calls checkpoint manifest-declared files, and success/failure terminal paths perform one
-  final best-effort scan. A busy cancellation skips that scan and preserves earlier checkpoints. Direct `nat run` does
-  not provide that store, and adding a sandbox alone does not guarantee that every generated file is persisted or
-  embedded in the report.
+- The reference profile enables durable sandbox artifact capture for async API jobs. Successful `execute` calls
+  checkpoint manifest-declared files, and success/failure terminal paths perform one final best-effort scan. A busy
+  cancellation skips that scan and preserves earlier checkpoints. Adding a sandbox alone does not guarantee that every
+  generated file is persisted or embedded in the report.

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -204,6 +204,13 @@ curl http://localhost:8000/v1/jobs/async/job/{job_id}
 
 Job statuses: `SUBMITTED`, `RUNNING`, `SUCCESS`, `FAILURE`, `INTERRUPTED`.
 
+Typed source-condition failures, such as running with no selected sources or receiving no
+results from the selected sources, remain in `FAILURE`. Their `error` is an actionable
+message describing how to correct the source selection or query. If the agent produced a
+sanitized answer before detecting the source condition, that report remains available from
+`GET /v1/jobs/async/job/{job_id}/report`. Unexpected failures continue to return a sanitized
+error and do not expose internal exception details or plaintext output.
+
 ### Stream Events (SSE)
 
 Stream real-time events from a running or completed job using Server-Sent Events.

--- a/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
@@ -126,6 +126,15 @@ class IntermediateStepEvent(BaseModel):
         return {k: v for k, v in result.items() if v is not None}
 
 
+def build_final_report_event(content: str) -> IntermediateStepEvent:
+    """Build the canonical final-report artifact event."""
+    return IntermediateStepEvent(
+        category=EventCategory.ARTIFACT,
+        state=EventState.UPDATE,
+        data=EventData(type=ArtifactType.OUTPUT.value, content=content, output_category="final_report"),
+    )
+
+
 class ToolArtifactMapping:
     """
     Maps tool names to artifact types for automatic artifact emission.
@@ -381,11 +390,7 @@ class AgentEventCallback(BaseCallbackHandler):
         frontend receives the verified content (overwrites the earlier
         auto-emitted version).
         """
-        self._emit_artifact(
-            ArtifactType.OUTPUT,
-            content,
-            output_category="final_report",
-        )
+        self._emit(build_final_report_event(content))
 
     def _is_search_tool(self, tool_name: str) -> bool:
         """Check if tool is a search-related tool that returns URLs."""

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -35,7 +35,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 from typing import Any
 
+from aiq_agent.common.citation_verification import EmptySourceRegistryError
+
 from .callbacks import AgentEventCallback
+from .callbacks import build_final_report_event
 from .event_store import BatchingEventStore
 from .event_store import EventStore
 
@@ -236,6 +239,109 @@ def _write_job_success_if_running_sync(db_url: str, job_id: str, stored_output: 
     with engine.begin() as conn:
         result = conn.execute(stmt, {"output": stored_output, "job_id": job_id})
         return (result.rowcount or 0) == 1
+
+
+def _write_job_source_failure_if_running_sync(
+    db_url: str,
+    job_id: str,
+    public_error: str,
+    stored_output: str,
+    final_report_event: dict[str, Any] | None = None,
+    job_output_cipher: Any | None = None,
+) -> bool:
+    """Persist a source failure, then store its optional final-report event best-effort."""
+    from sqlalchemy import text
+
+    from .event_store import EventStore
+
+    engine = EventStore._get_or_create_sync_engine(db_url)
+    stmt = text(
+        f"UPDATE job_info SET status = 'failure', error = :error, output = :output, "
+        f"updated_at = {_db_now_expr(db_url)} WHERE job_id = :job_id AND status = 'running'"
+    )
+    with engine.begin() as conn:
+        result = conn.execute(
+            stmt,
+            {"error": public_error, "output": stored_output, "job_id": job_id},
+        )
+        if (result.rowcount or 0) != 1:
+            return False
+
+    if final_report_event is not None:
+        try:
+            EventStore(db_url, job_id, content_cipher=job_output_cipher).store(final_report_event)
+        except Exception as exc:
+            logger.warning(
+                "Job %s source-failure final-report event write failed exception=%s",
+                job_id,
+                exc.__class__.__name__,
+            )
+    return True
+
+
+def _write_job_failure_if_running_sync(db_url: str, job_id: str, public_error: str) -> bool:
+    """Compare-and-set a generic failure without changing an existing terminal job."""
+    from sqlalchemy import text
+
+    from .event_store import EventStore
+
+    engine = EventStore._get_or_create_sync_engine(db_url)
+    stmt = text(
+        f"UPDATE job_info SET status = 'failure', error = :error, updated_at = {_db_now_expr(db_url)} "
+        "WHERE job_id = :job_id AND status = 'running'"
+    )
+    with engine.begin() as conn:
+        result = conn.execute(stmt, {"error": public_error, "job_id": job_id})
+        return (result.rowcount or 0) == 1
+
+
+async def _persist_empty_source_failure(
+    *,
+    error: EmptySourceRegistryError,
+    job_output_cipher: Any,
+    db_url: str,
+    job_id: str,
+    event_store: Any | None = None,
+) -> bool:
+    """Persist a typed source failure, falling back safely if output storage fails."""
+    from .crypto import serialize_job_output_for_storage
+
+    output = {
+        "report": error.generated_answer,
+        "outcome_reason": error.reason.value,
+    }
+    try:
+        stored_output = serialize_job_output_for_storage(output, job_output_cipher)
+        if event_store is not None and hasattr(event_store, "flush"):
+            await asyncio.to_thread(event_store.flush)
+        final_report_event = (
+            build_final_report_event(error.generated_answer).to_sse_dict() if error.generated_answer else None
+        )
+        return await asyncio.get_running_loop().run_in_executor(
+            None,
+            _write_job_source_failure_if_running_sync,
+            db_url,
+            job_id,
+            error.public_message,
+            stored_output,
+            final_report_event,
+            job_output_cipher,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Job %s source-failure output write failed exception=%s",
+            job_id,
+            exc.__class__.__name__,
+        )
+        sanitized_error = f"job failed ({type(exc).__name__}); check server logs for details"
+        await asyncio.get_running_loop().run_in_executor(
+            None,
+            _write_job_failure_if_running_sync,
+            db_url,
+            job_id,
+            sanitized_error,
+        )
+        return False
 
 
 def _run_lease_refresher(db_url: str, job_id: str, stop_event: threading.Event) -> None:
@@ -957,6 +1063,24 @@ async def run_agent_job(
                     await job_store.update_status(job_id, JobStatus.INTERRUPTED, error="cancelled by user")
             except (ConnectionError, TimeoutError, RuntimeError):
                 pass
+
+    except EmptySourceRegistryError as e:
+        logger.info("Job %s failed because no research sources were available (%s)", job_id, e.reason.value)
+        if event_store is None:
+            event_store = BatchingEventStore(EventStore(db_url, job_id, content_cipher=job_output_cipher))
+
+        await asyncio.to_thread(_harvest_sandbox_artifacts, sandbox_runtime, job_id=job_id, interrupted=False)
+        wrote = await _persist_empty_source_failure(
+            error=e,
+            job_output_cipher=job_output_cipher,
+            db_url=db_url,
+            job_id=job_id,
+            event_store=event_store,
+        )
+        if wrote:
+            logger.info("Job %s persisted source-failure outcome", job_id)
+        else:
+            logger.warning("Job %s already terminal or source-failure output persistence failed", job_id)
 
     except Exception as e:
         logger.exception("Job %s failed: %s", job_id, type(e).__name__)

--- a/frontends/aiq_api/tests/test_content_encryption_routes.py
+++ b/frontends/aiq_api/tests/test_content_encryption_routes.py
@@ -80,7 +80,15 @@ def _enable_vault(monkeypatch) -> None:
     crypto.reset_content_encryption_manager_for_tests()
 
 
-async def _build_jobs_app(monkeypatch, tmp_path, *, job_output=None, submitted_job=None) -> FastAPI:
+async def _build_jobs_app(
+    monkeypatch,
+    tmp_path,
+    *,
+    job_output=None,
+    job_status="success",
+    job_error=None,
+    submitted_job=None,
+) -> FastAPI:
     import aiq_api.routes.jobs as jobs_routes
     from aiq_api.jobs import access
     from aiq_api.jobs import event_store
@@ -112,8 +120,8 @@ async def _build_jobs_app(monkeypatch, tmp_path, *, job_output=None, submitted_j
 
     job = SimpleNamespace(
         job_id="job-1",
-        status="success",
-        error=None,
+        status=job_status,
+        error=job_error,
         output=job_output,
         created_at=datetime.now(UTC),
     )
@@ -581,6 +589,53 @@ async def test_report_decrypts_encrypted_final_output(monkeypatch, tmp_path):
         "interaction_action": "edit",
         "result_kind": "report",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outcome_reason", "actionable_error"),
+    [
+        (
+            "no_sources_selected",
+            "No data sources are selected. Select at least one data source and run the research again.",
+        ),
+        (
+            "no_source_results",
+            "The selected data sources returned no results. "
+            "Try rephrasing the question or selecting different data sources.",
+        ),
+    ],
+)
+async def test_source_failure_status_is_actionable_and_preserved_report_is_available(
+    monkeypatch, tmp_path, outcome_reason, actionable_error
+):
+    _enable_static_key(monkeypatch)
+    stored = crypto.create_job_content_cipher("job-1").encrypt_output_json(
+        json.dumps(
+            {
+                "report": "# Preserved generated answer",
+                "outcome_reason": outcome_reason,
+            }
+        )
+    )
+    app = await _build_jobs_app(
+        monkeypatch,
+        tmp_path,
+        job_output=stored,
+        job_status="failure",
+        job_error=actionable_error,
+    )
+
+    with TestClient(app) as client:
+        status_response = client.get("/v1/jobs/async/job/job-1")
+        report_response = client.get("/v1/jobs/async/job/job-1/report")
+
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "failure"
+    assert status_response.json()["error"] == actionable_error
+    assert report_response.status_code == 200
+    assert report_response.json()["has_report"] is True
+    assert report_response.json()["report"] == "# Preserved generated answer"
 
 
 @pytest.mark.asyncio

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -225,20 +225,7 @@ class ChatResearcherAgent:
                 result = await self.shallow_research_fn(shallow_state)
             except EmptySourceRegistryError as exc:
                 logger.warning("Shallow research produced no verifiable sources")
-                if exc.unavailable_tools:
-                    from aiq_agent.common.tool_validation import format_user_facing_tool_error
-
-                    err_msg = format_user_facing_tool_error(
-                        "shallow research",
-                        exc.unavailable_tools,
-                        exc.available_count,
-                    )
-                else:
-                    err_msg = (
-                        "The search tools did not return any results for this question. "
-                        "This may be due to a temporary issue or the question may need to be rephrased. "
-                        "Please try again."
-                    )
+                err_msg = exc.public_response
                 # confidence="high" reflects certainty that an error occurred and that the error
                 # message is the correct response — not uncertainty about the answer quality.
                 # escalate_to_deep=False because retrying deep research will not resolve a
@@ -358,20 +345,7 @@ class ChatResearcherAgent:
                 result = await self.deep_research_fn(deep_state)
             except EmptySourceRegistryError as exc:
                 logger.warning("Deep research produced no verifiable sources")
-                if exc.unavailable_tools:
-                    from aiq_agent.common.tool_validation import format_user_facing_tool_error
-
-                    err_msg = format_user_facing_tool_error(
-                        "deep research",
-                        exc.unavailable_tools,
-                        exc.available_count,
-                    )
-                else:
-                    err_msg = (
-                        "The search tools did not return any results for this question. "
-                        "This may be due to a temporary issue or the question may need to be rephrased. "
-                        "Please try again."
-                    )
+                err_msg = exc.public_response
                 return {
                     "messages": [AIMessage(content=err_msg)],
                     "workflow_outcome": _research_workflow_failure(),

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -30,6 +30,7 @@ from langchain_core.tools import BaseTool
 
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import load_prompt
+from aiq_agent.common import validate_research_source_configuration
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import source_entries_from_parent_context
@@ -249,6 +250,10 @@ class DeepResearcherAgent:
         """
         Execute deep research with multi-phase workflow.
         """
+        # Both the NAT registrar and async job runner call this interface, so source
+        # selection and availability must be enforced here rather than by either adapter.
+        validate_research_source_configuration(state.data_sources, "deep research", self.tools)
+
         prepared_files = self.deepagents_runtime.prepare_state_files(dict(state.files))
         if prepared_files != state.files:
             state = state.model_copy(update={"files": prepared_files})
@@ -273,6 +278,27 @@ class DeepResearcherAgent:
                 state.files,
                 final_report_tracker=final_report_tracker,
             )
+            # Capturing no sources is a research outcome failure even when citation
+            # rewriting is disabled; enable_citation_verification only controls the latter.
+            if not self.source_registry_middleware.has_sources():
+                from aiq_agent.common.citation_verification import classify_empty_source_registry_reason
+                from aiq_agent.common.tool_validation import validate_tool_availability
+
+                _, available_count, unavailable = validate_tool_availability(
+                    self.tools,
+                    research_type="deep research",
+                    enable_logging=False,
+                )
+                generated_answer = None
+                if final_message is not None:
+                    generated_answer = sanitize_report(final_message).sanitized_report
+                raise EmptySourceRegistryError(
+                    "deep research",
+                    unavailable_tools=unavailable,
+                    available_count=available_count,
+                    reason=classify_empty_source_registry_reason(state.data_sources, available_count, unavailable),
+                    generated_answer=generated_answer,
+                )
             if final_message is None:
                 raise RuntimeError("writer_output_not_committed")
 
@@ -302,20 +328,6 @@ class DeepResearcherAgent:
                         "returning the generated report without failing the job. "
                         "This may indicate unsupported citation formatting or over-aggressive verification."
                     )
-            elif self.enable_citation_verification:
-                from aiq_agent.common.tool_validation import validate_tool_availability
-
-                _, available_count, unavailable = validate_tool_availability(
-                    self.tools,
-                    research_type="deep research",
-                    enable_logging=False,
-                )
-                raise EmptySourceRegistryError(
-                    "deep research",
-                    unavailable_tools=unavailable,
-                    available_count=available_count,
-                )
-
             # Post-process: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
             sanitization = sanitize_report(final_message)
             final_message = sanitization.sanitized_report

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -32,6 +32,7 @@ from aiq_agent.common import LLMProvider
 from aiq_agent.common import load_prompt
 from aiq_agent.common import validate_research_source_configuration
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import EmptySourceRegistryReason
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import source_entries_from_parent_context
 from aiq_agent.common.citation_verification import verify_citations
@@ -368,6 +369,10 @@ class DeepResearcherAgent:
             logger.info("=" * 80)
             return DeepResearchAgentState.model_validate(result)
 
+        except EmptySourceRegistryError as ex:
+            if ex.reason is not EmptySourceRegistryReason.NO_SOURCE_RESULTS:
+                logger.error("Deep Research Subagent failed: %s", ex, exc_info=True)
+            raise
         except Exception as ex:
             logger.error("Deep Research Subagent failed: %s", ex, exc_info=True)
             raise

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -31,6 +31,8 @@ from aiq_agent.common import _create_chat_response
 from aiq_agent.common import all_mapped_tools_filtered_out
 from aiq_agent.common import filter_tools_by_sources
 from aiq_agent.common import is_verbose
+from aiq_agent.common import validate_research_source_configuration
+from aiq_agent.common.citation_verification import EmptySourceRegistryError
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
@@ -242,6 +244,8 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
         interrupted = False
         try:
             data_sources = state.data_sources
+            validate_research_source_configuration(data_sources, "deep research")
+
             selected_tools = filter_tools_by_sources(tools, data_sources)
             if sandbox_config is not None or (data_sources is not None and selected_tools != tools):
                 # Scope the Modal sandbox to the async job_id when one is in
@@ -273,25 +277,6 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
 
             if all_mapped_tools_filtered_out(tools, selected_tools, data_sources):
                 logger.warning("Deep research received data_sources with no matching tools")
-
-            # Validate tool availability before starting deep research
-            # At least one tool must be available
-            # This prevents the agent from trying to reason about unavailable tools
-            # Check selected_tools directly - they already reflect data_sources filtering
-            from aiq_agent.common import format_user_facing_tool_error
-            from aiq_agent.common import validate_tool_availability
-
-            is_valid, _, unavailable_tools = validate_tool_availability(selected_tools, research_type="deep research")
-
-            # Fail if no tools are available
-            if not is_valid:
-                error_msg = format_user_facing_tool_error("deep research", unavailable_tools)
-
-                # Return error state with error message - this prevents the agent from running
-                from langchain_core.messages import AIMessage
-
-                error_state = DeepResearchAgentState(messages=state.messages + [AIMessage(content=error_msg)])
-                return error_state
 
             result = await active_agent.run(state)
             return result
@@ -333,8 +318,11 @@ async def deep_research_workflow(config: DeepResearchWorkflowConfig, builder: Bu
     async def _run(query: str) -> ChatResponse:
         """Run deep research on a query string."""
         state = DeepResearchAgentState(messages=[HumanMessage(content=query)])
-        result = await deep_research_agent_fn.ainvoke(state)
-        response_content = result.messages[-1].content
+        try:
+            result = await deep_research_agent_fn.ainvoke(state)
+            response_content = result.messages[-1].content
+        except EmptySourceRegistryError as exc:
+            response_content = exc.public_response
         return _create_chat_response(response_content, response_id="research_response", model=workflow_id)
 
     yield FunctionInfo.from_fn(_run, description="Deep research workflow for evaluation (accepts string query).")

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -357,11 +357,29 @@ class ShallowResearcherAgent:
 
         # Post-process: verify citations against source registry
         validated_result = dict(result)
-        if validated_result.get("messages"):
-            last_msg = validated_result["messages"][-1]
-            if hasattr(last_msg, "content") and last_msg.content:
-                content = str(last_msg.content)
+        last_msg = validated_result["messages"][-1] if validated_result.get("messages") else None
+        content = str(last_msg.content) if last_msg is not None and getattr(last_msg, "content", None) else None
 
+        if not registry.all_sources():
+            from aiq_agent.common.citation_verification import classify_empty_source_registry_reason
+            from aiq_agent.common.tool_validation import validate_tool_availability
+
+            _, available_count, unavailable = validate_tool_availability(
+                self.tools,
+                research_type="shallow research",
+                enable_logging=False,
+            )
+            generated_answer = sanitize_report(content).sanitized_report if content is not None else None
+            raise EmptySourceRegistryError(
+                "shallow research",
+                unavailable_tools=unavailable,
+                available_count=available_count,
+                reason=classify_empty_source_registry_reason(state.data_sources, available_count, unavailable),
+                generated_answer=generated_answer,
+            )
+
+        if validated_result.get("messages"):
+            if content is not None:
                 # Step 1: verify citations against registry
                 if registry.all_sources():
                     verification = verify_citations(content, registry)
@@ -376,20 +394,6 @@ class ShallowResearcherAgent:
                     sources = registry.all_sources()
                     if not verification.valid_citations and len(sources) == 1:
                         content = _append_minimal_citation(content, sources[0])
-                else:
-                    from aiq_agent.common.tool_validation import validate_tool_availability
-
-                    _, available_count, unavailable = validate_tool_availability(
-                        self.tools,
-                        research_type="shallow research",
-                        enable_logging=False,
-                    )
-                    raise EmptySourceRegistryError(
-                        "shallow research",
-                        unavailable_tools=unavailable,
-                        available_count=available_count,
-                    )
-
                 # Step 2: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
                 sanitization = sanitize_report(content)
                 content = sanitization.sanitized_report

--- a/src/aiq_agent/agents/shallow_researcher/register.py
+++ b/src/aiq_agent/agents/shallow_researcher/register.py
@@ -26,6 +26,8 @@ from aiq_agent.common import _create_chat_response
 from aiq_agent.common import all_mapped_tools_filtered_out
 from aiq_agent.common import filter_tools_by_sources
 from aiq_agent.common import is_verbose
+from aiq_agent.common import validate_research_source_configuration
+from aiq_agent.common.citation_verification import EmptySourceRegistryError
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
@@ -104,6 +106,8 @@ async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Bu
 
         try:
             data_sources = state.data_sources
+            validate_research_source_configuration(data_sources, "shallow research")
+
             selected_tools = filter_tools_by_sources(tools, data_sources)
 
             if all_mapped_tools_filtered_out(tools, selected_tools, data_sources):
@@ -171,19 +175,7 @@ async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Bu
                     callbacks=callbacks,
                 )
 
-                # Require at least one available tool, else the agent would reason about
-                # tools it can't call. selected_tools already reflects filtering + MCP.
-                from aiq_agent.common import format_user_facing_tool_error
-                from aiq_agent.common import validate_tool_availability
-
-                is_valid, _, unavailable_tools = validate_tool_availability(
-                    selected_tools, research_type="shallow research"
-                )
-                if not is_valid:
-                    error_msg = format_user_facing_tool_error("shallow research", unavailable_tools)
-                    from langchain_core.messages import AIMessage
-
-                    return ShallowResearchAgentState(messages=state.messages + [AIMessage(content=error_msg)])
+                validate_research_source_configuration(data_sources, "shallow research", selected_tools)
 
                 return await active_agent.run(state)
         except Exception:
@@ -214,10 +206,13 @@ async def shallow_research_workflow(config: ShallowResearchWorkflowConfig, build
 
     async def _run(query: str) -> ChatResponse:
         """Run shallow research on a query string."""
-        result = await shallow_research_agent_fn.ainvoke(
-            ShallowResearchAgentState(messages=[HumanMessage(content=query)])
-        )
-        response_content = result.messages[-1].content
+        try:
+            result = await shallow_research_agent_fn.ainvoke(
+                ShallowResearchAgentState(messages=[HumanMessage(content=query)])
+            )
+            response_content = result.messages[-1].content
+        except EmptySourceRegistryError as exc:
+            response_content = exc.public_response
         return _create_chat_response(response_content, response_id="research_response", model=workflow_id)
 
     yield FunctionInfo.from_fn(_run, description="Shallow research workflow for evaluation (accepts string query).")

--- a/src/aiq_agent/common/__init__.py
+++ b/src/aiq_agent/common/__init__.py
@@ -59,6 +59,7 @@ from .prompt_utils import load_prompt
 from .prompt_utils import render_prompt_template
 from .tool_validation import format_tool_unavailability_error
 from .tool_validation import format_user_facing_tool_error
+from .tool_validation import validate_research_source_configuration
 from .tool_validation import validate_tool_availability
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,7 @@ __all__ = [
     "reset_session_registry",
     "sanitize_report",
     "set_session_registry",
+    "validate_research_source_configuration",
     "validate_tool_availability",
     "verify_citations",
 ]

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -40,6 +40,7 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from dataclasses import dataclass
 from dataclasses import field
+from enum import StrEnum
 from html import unescape
 from urllib.parse import parse_qs
 from urllib.parse import unquote
@@ -105,6 +106,42 @@ class CitationVerificationResult:
     valid_citations: list[dict] = field(default_factory=list)
 
 
+class EmptySourceRegistryReason(StrEnum):
+    """Stable classifications for research completing without sources."""
+
+    NO_SOURCES_SELECTED = "no_sources_selected"
+    NO_SOURCE_RESULTS = "no_source_results"
+    SOURCE_TOOLS_UNAVAILABLE = "source_tools_unavailable"
+
+    @property
+    def public_message(self) -> str:
+        """Return safe remediation suitable for direct display to users."""
+        if self is EmptySourceRegistryReason.NO_SOURCES_SELECTED:
+            return "No data sources are selected. Select at least one data source and run the research again."
+        if self is EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE:
+            return (
+                "The selected data source tools are currently unavailable. "
+                "Check their configuration or select different data sources and run the research again."
+            )
+        return (
+            "The selected data sources returned no results. "
+            "Try rephrasing the question or selecting different data sources."
+        )
+
+
+def classify_empty_source_registry_reason(
+    data_sources: list[str] | None,
+    available_count: int,
+    unavailable_tools: list[str],
+) -> EmptySourceRegistryReason:
+    """Classify an empty source registry without conflating selection and availability."""
+    if data_sources == []:
+        return EmptySourceRegistryReason.NO_SOURCES_SELECTED
+    if available_count == 0 and unavailable_tools:
+        return EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE
+    return EmptySourceRegistryReason.NO_SOURCE_RESULTS
+
+
 class EmptySourceRegistryError(Exception):
     """Raised when no sources were captured during research."""
 
@@ -113,16 +150,27 @@ class EmptySourceRegistryError(Exception):
         agent_type: str = "research",
         unavailable_tools: list[str] | None = None,
         available_count: int = 0,
+        reason: EmptySourceRegistryReason = EmptySourceRegistryReason.NO_SOURCE_RESULTS,
+        generated_answer: str | None = None,
     ) -> None:
         """Build the empty-registry error with agent type and tool-availability context."""
         self.agent_type = agent_type
         self.unavailable_tools = unavailable_tools or []
         self.available_count = available_count
+        self.reason = reason
+        self.public_message = reason.public_message
+        self.generated_answer = generated_answer
         super().__init__(
             f"Research failed: no sources were captured during {agent_type}. "
-            "All tool calls may have failed or returned no results. "
-            "Please try again."
+            "All tool calls may have failed or returned no results."
         )
+
+    @property
+    def public_response(self) -> str:
+        """Return the generated answer, when present, with remediation."""
+        if self.generated_answer and self.generated_answer.strip():
+            return f"{self.generated_answer.rstrip()}\n\n{self.public_message}"
+        return self.public_message
 
 
 _TRACKING_PARAMS = frozenset(

--- a/src/aiq_agent/common/tool_validation.py
+++ b/src/aiq_agent/common/tool_validation.py
@@ -100,6 +100,35 @@ def validate_tool_availability(
     return available_tools_count > 0, available_tools_count, unavailable_tools
 
 
+def validate_research_source_configuration(
+    data_sources: list[str] | None,
+    research_type: str,
+    tools: list[Any] | None = None,
+) -> None:
+    """Raise a typed error for an empty selection or unavailable tool set."""
+    from .citation_verification import EmptySourceRegistryError
+    from .citation_verification import EmptySourceRegistryReason
+    from .citation_verification import classify_empty_source_registry_reason
+
+    if data_sources == []:
+        raise EmptySourceRegistryError(
+            research_type,
+            reason=EmptySourceRegistryReason.NO_SOURCES_SELECTED,
+        )
+
+    if tools is None:
+        return
+
+    is_valid, available_count, unavailable_tools = validate_tool_availability(tools, research_type=research_type)
+    if not is_valid:
+        raise EmptySourceRegistryError(
+            research_type,
+            unavailable_tools=unavailable_tools,
+            available_count=available_count,
+            reason=classify_empty_source_registry_reason(data_sources, available_count, unavailable_tools),
+        )
+
+
 def format_tool_unavailability_error(
     research_type: str,
     unavailable_tools: list[str],

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -28,6 +28,8 @@ from aiq_agent.agents.chat_researcher.models import ChatResearcherState
 from aiq_agent.agents.chat_researcher.models import DepthDecision
 from aiq_agent.agents.chat_researcher.models import IntentResult
 from aiq_agent.agents.chat_researcher.models import WorkflowFailure
+from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import EmptySourceRegistryReason
 from aiq_agent.common.logging_utils import log_identifier_ref
 
 
@@ -239,6 +241,78 @@ class TestChatResearcherAgent:
         assert "try again" in result["messages"][-1].content.lower()
         assert result["workflow_outcome"] == WorkflowFailure(error=RESEARCH_WORKFLOW_FAILURE_ERROR)
         assert "provider detail" not in result["workflow_outcome"].error
+
+    @pytest.mark.parametrize("depth", ["shallow", "deep"])
+    @pytest.mark.parametrize("generated_answer", [None, "Sanitized generated answer."])
+    @pytest.mark.asyncio
+    async def test_empty_source_failure_returns_generated_answer_and_typed_remediation(
+        self,
+        mock_clarifier,
+        depth,
+        generated_answer,
+    ):
+        async def orchestration(_state):
+            return {
+                "user_intent": IntentResult(intent="research", target="new_research", raw=None),
+                "depth_decision": DepthDecision(decision=depth, raw_reasoning="test"),
+            }
+
+        async def empty_sources(_state):
+            raise EmptySourceRegistryError(
+                reason=EmptySourceRegistryReason.NO_SOURCES_SELECTED,
+                generated_answer=generated_answer,
+            )
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=orchestration,
+            shallow_research_fn=empty_sources,
+            deep_research_fn=empty_sources,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+            enable_escalation=False,
+        )
+
+        result = await agent.run(
+            ChatResearcherState(messages=[HumanMessage(content="Research this")]),
+            thread_id=f"test-empty-sources-{depth}-{generated_answer is not None}",
+        )
+
+        content = result["messages"][-1].content
+        if generated_answer:
+            assert content.startswith(f"{generated_answer}\n\n")
+        assert "No data sources are selected" in content
+        assert "Please try again" not in content
+        assert result["workflow_outcome"] == WorkflowFailure(error=RESEARCH_WORKFLOW_FAILURE_ERROR)
+
+    @pytest.mark.parametrize("depth", ["shallow", "deep"])
+    @pytest.mark.asyncio
+    async def test_unavailable_source_tools_preserve_actionable_remediation(self, mock_clarifier, depth):
+        async def orchestration(_state):
+            return {
+                "user_intent": IntentResult(intent="research", target="new_research", raw=None),
+                "depth_decision": DepthDecision(decision=depth, raw_reasoning="test"),
+            }
+
+        async def unavailable_sources(_state):
+            raise EmptySourceRegistryError(reason=EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE)
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=orchestration,
+            shallow_research_fn=unavailable_sources,
+            deep_research_fn=unavailable_sources,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+            enable_escalation=False,
+        )
+
+        result = await agent.run(
+            ChatResearcherState(messages=[HumanMessage(content="Research this")]),
+            thread_id=f"test-unavailable-sources-{depth}",
+        )
+
+        assert "data source tools are currently unavailable" in result["messages"][-1].content
+        assert "returned no results" not in result["messages"][-1].content
+        assert result["workflow_outcome"] == WorkflowFailure(error=RESEARCH_WORKFLOW_FAILURE_ERROR)
 
     @pytest.mark.asyncio
     async def test_run_deep_research_flow(

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -42,6 +42,8 @@ from aiq_agent.agents.deep_researcher.tools.research import build_research_batch
 from aiq_agent.agents.deep_researcher.tools.research import researcher_invoke_state
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
+from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import EmptySourceRegistryReason
 from aiq_agent.common.citation_verification import SourceEntry
 from aiq_api.jobs.callbacks import AgentEventCallback
 
@@ -350,6 +352,84 @@ class TestDeepResearcherAgent:
             request_agent.finalize.assert_called_once_with(interrupted=True)
         else:
             request_agent.finalize.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("data_sources", "tool_description", "expected_reason"),
+        [
+            ([], "Search the web for information.", EmptySourceRegistryReason.NO_SOURCES_SELECTED),
+            (None, "Web search (unavailable - missing API key)", EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_registered_run_raises_typed_source_configuration_failure(
+        self, data_sources, tool_description, expected_reason
+    ):
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_agent.agents.deep_researcher.register import deep_research_agent
+
+        builder = MagicMock()
+        builder.get_tools = AsyncMock(return_value=[web_search_tool])
+        builder.get_llm = AsyncMock(return_value=MagicMock())
+        config = DeepResearchAgentConfig(orchestrator_llm="llm", tools=["web_search_tool"], verbose=False)
+        state = DeepResearchAgentState(messages=[HumanMessage(content="research this")], data_sources=data_sources)
+        original_description = web_search_tool.description
+        web_search_tool.description = tool_description
+
+        try:
+            registration = deep_research_agent.__wrapped__(config, builder)
+            function_info = await anext(registration)
+            try:
+                with pytest.raises(EmptySourceRegistryError) as exc_info:
+                    await function_info.single_fn(state)
+            finally:
+                await registration.aclose()
+        finally:
+            web_search_tool.description = original_description
+
+        assert exc_info.value.reason is expected_reason
+
+    @pytest.mark.asyncio
+    async def test_explicit_empty_selection_skips_request_agent_setup(self):
+        from aiq_agent.agents.deep_researcher import register as deep_register
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_agent.agents.deep_researcher.register import deep_research_agent
+
+        builder = MagicMock()
+        builder.get_tools = AsyncMock(return_value=[web_search_tool])
+        builder.get_llm = AsyncMock(return_value=MagicMock())
+        config = DeepResearchAgentConfig(orchestrator_llm="llm", tools=["web_search_tool"], verbose=False)
+        state = DeepResearchAgentState(messages=[HumanMessage(content="research this")], data_sources=[])
+
+        with patch.object(deep_register, "filter_tools_by_sources") as filter_tools:
+            registration = deep_research_agent.__wrapped__(config, builder)
+            function_info = await anext(registration)
+            try:
+                with pytest.raises(EmptySourceRegistryError):
+                    await function_info.single_fn(state)
+            finally:
+                await registration.aclose()
+
+        filter_tools.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deep_evaluation_wrapper_returns_public_response_for_empty_sources(self):
+        from aiq_agent.agents.deep_researcher.register import DeepResearchWorkflowConfig
+        from aiq_agent.agents.deep_researcher.register import deep_research_workflow
+
+        error = EmptySourceRegistryError(generated_answer="A source-free draft")
+        agent_fn = MagicMock()
+        agent_fn.ainvoke = AsyncMock(side_effect=error)
+        builder = MagicMock()
+        builder.get_function = AsyncMock(return_value=agent_fn)
+
+        registration = deep_research_workflow.__wrapped__(DeepResearchWorkflowConfig(), builder)
+        function_info = await anext(registration)
+        try:
+            response = await function_info.single_fn("research this")
+        finally:
+            await registration.aclose()
+
+        assert response.choices[0].message.content == error.public_response
 
     def test_modal_sandbox_name_is_job_id(self):
         """Modal sandbox names use the resolved job ID directly."""
@@ -1247,6 +1327,111 @@ class TestDeepResearcherAgent:
             with pytest.raises(Exception, match="Agent error"):
                 await agent.run(state)
             assert mock_agent.ainvoke.await_count == 1
+
+    @pytest.mark.parametrize(
+        ("data_sources", "enable_citation_verification", "expected_reason"),
+        [
+            (None, True, EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+            (["web"], True, EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+            (None, False, EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_committed_output_empty_registry_classification_preserves_sanitized_answer(
+        self,
+        mock_llm_provider,
+        real_tool,
+        data_sources,
+        enable_citation_verification,
+        expected_reason,
+    ):
+        from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+        draft = "Draft answer with https://private.example/path"
+        mock_agent = MagicMock()
+        mock_agent.with_config = MagicMock(return_value=mock_agent)
+        mock_agent.ainvoke = AsyncMock(
+            return_value={"messages": [AIMessage(content="Writer complete")], "files": output_markdown_file(draft)}
+        )
+
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(draft),
+            ),
+        ):
+            agent = DeepResearcherAgent(
+                llm_provider=mock_llm_provider,
+                tools=[real_tool],
+                enable_citation_verification=enable_citation_verification,
+            )
+            state = DeepResearchAgentState(
+                messages=[HumanMessage(content="Test")],
+                data_sources=data_sources,
+            )
+
+            with pytest.raises(EmptySourceRegistryError) as exc_info:
+                await agent.run(state)
+
+        assert exc_info.value.reason is expected_reason
+        assert exc_info.value.generated_answer == "Draft answer with "
+
+    @pytest.mark.asyncio
+    async def test_empty_registry_is_classified_without_committed_writer_output(
+        self,
+        mock_llm_provider,
+        real_tool,
+    ):
+        mock_agent = MagicMock()
+        mock_agent.with_config = MagicMock(return_value=mock_agent)
+        mock_agent.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="No report")], "files": {}})
+
+        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent):
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(
+                llm_provider=mock_llm_provider,
+                tools=[real_tool],
+                enable_citation_verification=True,
+            )
+            state = DeepResearchAgentState(messages=[HumanMessage(content="Test")], data_sources=None)
+
+            with pytest.raises(EmptySourceRegistryError) as exc_info:
+                await agent.run(state)
+
+        assert exc_info.value.reason is EmptySourceRegistryReason.NO_SOURCE_RESULTS
+        assert exc_info.value.generated_answer is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_citation_verification_rejects_empty_selection_before_orchestrator(
+        self,
+        mock_llm_provider,
+        real_tool,
+    ):
+        mock_agent = MagicMock()
+        mock_agent.with_config = MagicMock(return_value=mock_agent)
+        mock_agent.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="No report")], "files": {}})
+
+        with patch(
+            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+            return_value=mock_agent,
+        ) as create_deep_agent:
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(
+                llm_provider=mock_llm_provider,
+                tools=[real_tool],
+                enable_citation_verification=False,
+            )
+            state = DeepResearchAgentState(messages=[HumanMessage(content="Test")], data_sources=[])
+
+            with pytest.raises(EmptySourceRegistryError) as exc_info:
+                await agent.run(state)
+
+        assert exc_info.value.reason is EmptySourceRegistryReason.NO_SOURCES_SELECTED
+        create_deep_agent.assert_not_called()
+        mock_agent.ainvoke.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_run_empty_result_messages(self, mock_llm_provider, real_tool):

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -1302,7 +1302,7 @@ class TestDeepResearcherAgent:
             assert call_kwargs is not None
 
     @pytest.mark.asyncio
-    async def test_run_handles_error(self, mock_llm_provider, real_tool):
+    async def test_run_handles_error(self, mock_llm_provider, real_tool, caplog):
         """Test run() handles errors gracefully."""
         mock_agent = MagicMock()
         mock_agent.with_config = MagicMock(return_value=mock_agent)
@@ -1324,9 +1324,11 @@ class TestDeepResearcherAgent:
 
             state = DeepResearchAgentState(messages=[HumanMessage(content="Test query")])
 
-            with pytest.raises(Exception, match="Agent error"):
-                await agent.run(state)
+            with caplog.at_level("ERROR", logger="aiq_agent.agents.deep_researcher.agent"):
+                with pytest.raises(Exception, match="Agent error"):
+                    await agent.run(state)
             assert mock_agent.ainvoke.await_count == 1
+            assert caplog.messages.count("Deep Research Subagent failed: Agent error") == 1
 
     @pytest.mark.parametrize(
         ("data_sources", "enable_citation_verification", "expected_reason"),
@@ -1344,6 +1346,7 @@ class TestDeepResearcherAgent:
         data_sources,
         enable_citation_verification,
         expected_reason,
+        caplog,
     ):
         from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
@@ -1371,11 +1374,13 @@ class TestDeepResearcherAgent:
                 data_sources=data_sources,
             )
 
-            with pytest.raises(EmptySourceRegistryError) as exc_info:
-                await agent.run(state)
+            with caplog.at_level("ERROR", logger="aiq_agent.agents.deep_researcher.agent"):
+                with pytest.raises(EmptySourceRegistryError) as exc_info:
+                    await agent.run(state)
 
         assert exc_info.value.reason is expected_reason
         assert exc_info.value.generated_answer == "Draft answer with "
+        assert not any(message.startswith("Deep Research Subagent failed:") for message in caplog.messages)
 
     @pytest.mark.asyncio
     async def test_empty_registry_is_classified_without_committed_writer_output(

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -30,6 +30,7 @@ from aiq_agent.agents.shallow_researcher.models import ShallowResearchAgentState
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import EmptySourceRegistryReason
 from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import SourceRegistry
 from aiq_agent.common.data_source_registry import populate_from_config
@@ -40,6 +41,12 @@ from aiq_agent.common.data_source_registry import reset_registry
 def web_search_tool(query: str) -> str:
     """Search the web for information."""
     return f"Results for: {query}"
+
+
+@tool
+def empty_web_search_tool(query: str) -> str:
+    """Search the web but return no usable evidence."""
+    return "Search returned no results"
 
 
 class TestShallowResearcherAgent:
@@ -810,6 +817,91 @@ class TestShallowResearcherSessionRegistry:
 
         with pytest.raises(EmptySourceRegistryError):
             await agent.run(state)
+
+    @pytest.mark.parametrize(
+        ("data_sources", "expected_reason"),
+        [
+            ([], EmptySourceRegistryReason.NO_SOURCES_SELECTED),
+            (None, EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+            (["web"], EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_empty_registry_classification_preserves_sanitized_answer(
+        self,
+        mock_llm_provider,
+        mock_llm,
+        data_sources,
+        expected_reason,
+    ):
+        mock_llm.ainvoke = AsyncMock(return_value=AIMessage(content="Draft answer with https://private.example/path"))
+        agent = ShallowResearcherAgent(llm_provider=mock_llm_provider, tools=[web_search_tool])
+        state = ShallowResearchAgentState(
+            messages=[HumanMessage(content="Test")],
+            data_sources=data_sources,
+        )
+
+        with pytest.raises(EmptySourceRegistryError) as exc_info:
+            await agent.run(state)
+
+        assert exc_info.value.reason is expected_reason
+        assert exc_info.value.generated_answer == "Draft answer with "
+
+    @pytest.mark.asyncio
+    async def test_enabled_source_empty_result_preserves_generated_answer(self, mock_llm_provider, mock_llm):
+        populate_from_config(
+            [
+                {
+                    "id": "web",
+                    "name": "Web Search",
+                    "description": "Search the web.",
+                    "tools": ["empty_web_search_tool"],
+                }
+            ]
+        )
+        tool_call = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "empty_web_search_tool",
+                    "args": {"query": "quantum computing"},
+                    "id": "empty-search-1",
+                }
+            ],
+        )
+        generated_answer = "No supporting sources were found, so I cannot provide a sourced answer."
+        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call, AIMessage(content=generated_answer)])
+        agent = ShallowResearcherAgent(llm_provider=mock_llm_provider, tools=[empty_web_search_tool])
+        state = ShallowResearchAgentState(
+            messages=[HumanMessage(content="Summarize quantum computing.")],
+            data_sources=["web"],
+        )
+
+        try:
+            with pytest.raises(EmptySourceRegistryError) as exc_info:
+                await agent.run(state)
+        finally:
+            reset_registry()
+
+        assert exc_info.value.reason is EmptySourceRegistryReason.NO_SOURCE_RESULTS
+        assert exc_info.value.generated_answer == generated_answer
+        assert "Try rephrasing the question" in exc_info.value.public_response
+        assert mock_llm.ainvoke.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_registry_without_final_message_raises_typed_failure(self, mock_llm_provider):
+        agent = ShallowResearcherAgent(llm_provider=mock_llm_provider, tools=[web_search_tool])
+        agent._graph = MagicMock()
+        agent._graph.ainvoke = AsyncMock(return_value={"messages": []})
+
+        with (
+            patch.object(SourceRegistry, "all_sources", return_value=[]),
+            pytest.raises(EmptySourceRegistryError) as exc_info,
+        ):
+            await agent.run(ShallowResearchAgentState(messages=[HumanMessage(content="Test")]))
+
+        assert exc_info.value.reason is EmptySourceRegistryReason.NO_SOURCE_RESULTS
+        assert exc_info.value.generated_answer is None
 
     @pytest.mark.asyncio
     async def test_session_registry_does_not_mutate_shared_instance(self, mock_llm_provider, mock_llm):

--- a/tests/aiq_agent/agents/shallow_researcher/test_register_per_user_mcp.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_register_per_user_mcp.py
@@ -21,6 +21,8 @@ from langchain_core.tools import tool
 
 from aiq_agent.agents.shallow_researcher import register as shallow_register
 from aiq_agent.agents.shallow_researcher.models import ShallowResearchAgentState
+from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import EmptySourceRegistryReason
 
 
 @tool
@@ -98,3 +100,58 @@ async def test_shallow_run_surfaces_reconnect_when_source_unavailable():
         assert "Reconnect them in the data sources panel" in content
     finally:
         await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_registered_shallow_run_raises_typed_no_sources_for_explicit_empty_selection():
+    """Explicit empty selection fails before filtering or per-user setup."""
+    run, agen = await _build_run()
+    try:
+        state = ShallowResearchAgentState(
+            messages=[HumanMessage(content="research this")],
+            data_sources=[],
+        )
+        with patch.object(shallow_register, "filter_tools_by_sources") as filter_tools:
+            with pytest.raises(EmptySourceRegistryError) as exc_info:
+                await run(state)
+
+        assert exc_info.value.reason is EmptySourceRegistryReason.NO_SOURCES_SELECTED
+        filter_tools.assert_not_called()
+    finally:
+        await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_registered_shallow_run_classifies_selected_unavailable_tool():
+    run, agen = await _build_run()
+    try:
+        _dummy_search.description = "Web search (unavailable - missing API key)"
+        state = ShallowResearchAgentState(messages=[HumanMessage(content="research this")])
+        with patch.dict(sys.modules, {m: None for m in _AIQ_API_MODULES}):
+            with pytest.raises(EmptySourceRegistryError) as exc_info:
+                await run(state)
+
+        assert exc_info.value.reason is EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE
+    finally:
+        _dummy_search.description = "Dummy search tool used to build the agent."
+        await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shallow_evaluation_wrapper_returns_public_response_for_empty_sources():
+    generated_answer = "A source-free draft"
+    error = EmptySourceRegistryError(generated_answer=generated_answer)
+    agent_fn = MagicMock()
+    agent_fn.ainvoke = AsyncMock(side_effect=error)
+    builder = MagicMock()
+    builder.get_function = AsyncMock(return_value=agent_fn)
+    config = shallow_register.ShallowResearchWorkflowConfig()
+
+    registration = shallow_register.shallow_research_workflow.__wrapped__(config, builder)
+    function_info = await anext(registration)
+    try:
+        response = await function_info.single_fn("research this")
+    finally:
+        await registration.aclose()
+
+    assert response.choices[0].message.content == error.public_response

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -19,10 +19,12 @@ import pytest
 
 from aiq_agent.common.citation_verification import _PARSER_REGISTRY
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import EmptySourceRegistryReason
 from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import SourceRegistry
 from aiq_agent.common.citation_verification import _normalize_url
 from aiq_agent.common.citation_verification import _parse_citation_key
+from aiq_agent.common.citation_verification import classify_empty_source_registry_reason
 from aiq_agent.common.citation_verification import extract_sources_from_tool_result
 from aiq_agent.common.citation_verification import register_source_parser
 from aiq_agent.common.citation_verification import sanitize_report
@@ -36,6 +38,78 @@ def fixture_restore_parser_registry():
     yield
     _PARSER_REGISTRY.clear()
     _PARSER_REGISTRY.extend(original)
+
+
+class TestEmptySourceRegistryContract:
+    """Tests for the public empty-source failure contract."""
+
+    @pytest.mark.parametrize(
+        ("reason", "expected_message"),
+        [
+            (
+                EmptySourceRegistryReason.NO_SOURCES_SELECTED,
+                "No data sources are selected. Select at least one data source and run the research again.",
+            ),
+            (
+                EmptySourceRegistryReason.NO_SOURCE_RESULTS,
+                "The selected data sources returned no results. "
+                "Try rephrasing the question or selecting different data sources.",
+            ),
+            (
+                EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE,
+                "The selected data source tools are currently unavailable. "
+                "Check their configuration or select different data sources and run the research again.",
+            ),
+        ],
+    )
+    def test_reason_has_safe_actionable_public_message(self, reason, expected_message):
+        error = EmptySourceRegistryError(reason=reason)
+
+        assert error.reason is reason
+        assert error.public_message == expected_message
+        assert "Please try again" not in error.public_message
+
+    def test_reason_values_are_stable(self):
+        assert [reason.value for reason in EmptySourceRegistryReason] == [
+            "no_sources_selected",
+            "no_source_results",
+            "source_tools_unavailable",
+        ]
+
+    @pytest.mark.parametrize(
+        ("data_sources", "available_count", "unavailable_tools", "expected"),
+        [
+            ([], 0, ["web_search (missing key)"], EmptySourceRegistryReason.NO_SOURCES_SELECTED),
+            (["web"], 0, ["web_search (missing key)"], EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE),
+            (None, 0, ["web_search (missing key)"], EmptySourceRegistryReason.SOURCE_TOOLS_UNAVAILABLE),
+            (["web"], 1, ["scholar_search (missing key)"], EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+            (["web"], 1, [], EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+            (None, 0, [], EmptySourceRegistryReason.NO_SOURCE_RESULTS),
+        ],
+    )
+    def test_classification_distinguishes_selection_availability_and_empty_results(
+        self, data_sources, available_count, unavailable_tools, expected
+    ):
+        assert classify_empty_source_registry_reason(data_sources, available_count, unavailable_tools) is expected
+
+    def test_preserves_compatibility_fields_and_optional_generated_answer(self):
+        error = EmptySourceRegistryError(
+            "deep research",
+            unavailable_tools=["web_search"],
+            available_count=2,
+            generated_answer="Sanitized draft",
+        )
+
+        assert error.agent_type == "deep research"
+        assert error.unavailable_tools == ["web_search"]
+        assert error.available_count == 2
+        assert error.generated_answer == "Sanitized draft"
+        assert error.reason is EmptySourceRegistryReason.NO_SOURCE_RESULTS
+        assert error.public_response == (
+            "Sanitized draft\n\n"
+            "The selected data sources returned no results. "
+            "Try rephrasing the question or selecting different data sources."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -90,6 +90,16 @@ def fixture_event_store_cache_guard():
     EventStore.dispose_all_engines()
 
 
+@pytest.fixture(name="content_encryption_manager_guard")
+def fixture_content_encryption_manager_guard():
+    """Reset content-encryption globals even when a test assertion fails."""
+    from aiq_api.jobs import crypto
+
+    crypto.reset_content_encryption_manager_for_tests()
+    yield
+    crypto.reset_content_encryption_manager_for_tests()
+
+
 class TestIntermediateStepEvent:
     """Tests for the IntermediateStepEvent model."""
 
@@ -910,6 +920,318 @@ class TestRunAgentJobEncryption:
             error="job failed (RuntimeError); check server logs for details",
         )
         update_job_output.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        ("reason", "generated_answer", "initial_status"),
+        [
+            ("no_sources_selected", None, "running"),
+            ("no_source_results", "# Preserved report", "running"),
+            ("no_source_results", "# Race-losing report", "success"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_empty_source_failure_persists_actionable_error_and_encrypted_outcome(
+        self, monkeypatch, tmp_path, reason, generated_answer, initial_status, content_encryption_manager_guard
+    ):
+        import base64
+        from contextlib import ExitStack
+        from types import SimpleNamespace
+
+        from sqlalchemy import text
+
+        from aiq_agent.common.citation_verification import EmptySourceRegistryError
+        from aiq_agent.common.citation_verification import EmptySourceRegistryReason
+        from aiq_api.jobs import crypto
+        from aiq_api.jobs.event_store import EventStore
+        from aiq_api.jobs.runner import run_agent_job
+        from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
+
+        class AsyncContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeWorkflowBuilder:
+            _telemetry_exporters = {}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get_function_config(self, _name):
+                return SimpleNamespace(tools=[], exclude_tools=[], verbose=False)
+
+            async def get_tools(self, *, tool_names, wrapper_type):  # noqa: ARG002 - mirrors NAT API
+                return []
+
+        class FakeExporterManager:
+            def start(self, *, context_state):  # noqa: ARG002 - mirrors NAT API
+                return AsyncContext()
+
+        typed_reason = EmptySourceRegistryReason(reason)
+        source_error = EmptySourceRegistryError(reason=typed_reason, generated_answer=generated_answer)
+        mock_job_store = MagicMock(update_status=AsyncMock())
+        config = SimpleNamespace(workflow=None, functions={}, middleware={})
+        monkeypatch.setenv("AIQ_CONTENT_ENCRYPTION", "key")
+        monkeypatch.setenv(
+            "AIQ_CONTENT_ENCRYPTION_KEY",
+            base64.urlsafe_b64encode(b"a" * crypto.DEK_BYTES).decode(),
+        )
+        monkeypatch.setenv("AIQ_CONTENT_ENCRYPTION_KEY_ID", "test-key")
+        encryption_policy = crypto.get_content_encryption_policy_identity()
+        db_url = f"sqlite:///{tmp_path / 'test.db'}"
+        engine = EventStore._get_or_create_sync_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE job_info (job_id TEXT PRIMARY KEY, status TEXT, error TEXT, "
+                    "output TEXT, updated_at TIMESTAMP)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO job_info (job_id, status, error, output) VALUES ('job-1', :status, 'original', 'kept')"
+                ),
+                {"status": initial_status},
+            )
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store)
+            )
+            stack.enter_context(patch("nat.runtime.loader.load_config", return_value=config))
+            stack.enter_context(
+                patch(
+                    "nat.builder.workflow_builder.WorkflowBuilder.from_config",
+                    return_value=FakeWorkflowBuilder(),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "nat.observability.exporter_manager.ExporterManager.from_exporters",
+                    return_value=FakeExporterManager(),
+                )
+            )
+            stack.enter_context(patch("aiq_api.jobs.runner._load_agent_class", return_value=object))
+            stack.enter_context(
+                patch("aiq_api.jobs.runner._create_llm_provider", AsyncMock(return_value=(object(), object())))
+            )
+            stack.enter_context(patch("aiq_api.jobs.runner._create_agent_instance", return_value=object()))
+            stack.enter_context(patch("aiq_api.jobs.runner._run_agent", AsyncMock(side_effect=source_error)))
+            await run_agent_job(
+                False,
+                20,
+                "tcp://localhost:8786",
+                db_url,
+                "config.yml",
+                "job-1",
+                "input",
+                "aiq_agent.agents.deep_researcher.agent.DeepResearcherAgent",
+                "deep_research_agent",
+                content_encryption_policy=encryption_policy,
+            )
+
+        with engine.connect() as conn:
+            row = conn.execute(text("SELECT status, error, output FROM job_info WHERE job_id = 'job-1'")).one()
+
+        if initial_status == "running":
+            assert row.status == "failure"
+            assert row.error == typed_reason.public_message
+            assert row.output.startswith(crypto.ENVELOPE_PREFIX)
+            if generated_answer:
+                assert generated_answer not in row.output
+            assert crypto.read_job_output("job-1", row.output) == {
+                "report": generated_answer,
+                "outcome_reason": reason,
+            }
+        else:
+            assert tuple(row) == ("success", "original", "kept")
+        assert [call.args[1] for call in mock_job_store.update_status.await_args_list] == [JobStatus.RUNNING]
+        events = EventStore.get_events(db_url, "job-1")
+        assert not any(event["type"] == "job.error" for event in events)
+        final_reports = [
+            event
+            for event in events
+            if event["type"] == "artifact.update" and event.get("data", {}).get("output_category") == "final_report"
+        ]
+        if generated_answer and initial_status == "running":
+            assert [event["data"]["content"] for event in final_reports] == [generated_answer]
+        else:
+            assert final_reports == []
+
+    @pytest.mark.asyncio
+    async def test_source_failure_event_write_failure_preserves_typed_outcome(self, tmp_path):
+        from sqlalchemy import text
+
+        from aiq_agent.common.citation_verification import EmptySourceRegistryError
+        from aiq_api.jobs.event_store import EventStore
+        from aiq_api.jobs.runner import _persist_empty_source_failure
+
+        db_url = f"sqlite:///{tmp_path / 'event-failure.db'}"
+        EventStore._ensure_table_exists(db_url)
+        engine = EventStore._get_or_create_sync_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE job_info (job_id TEXT PRIMARY KEY, status TEXT, error TEXT, "
+                    "output TEXT, updated_at TIMESTAMP)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO job_info (job_id, status, error, output) "
+                    "VALUES ('job-1', 'running', 'original', 'kept')"
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE TRIGGER reject_job_event BEFORE INSERT ON job_events "
+                    "BEGIN SELECT RAISE(FAIL, 'event insert failed'); END"
+                )
+            )
+
+        source_error = EmptySourceRegistryError(generated_answer="# Preserved report")
+        with patch("aiq_api.jobs.crypto.serialize_job_output_for_storage", return_value="stored-output"):
+            wrote = await _persist_empty_source_failure(
+                error=source_error,
+                job_output_cipher=None,
+                db_url=db_url,
+                job_id="job-1",
+            )
+
+        with engine.connect() as conn:
+            row = conn.execute(text("SELECT status, error, output FROM job_info WHERE job_id = 'job-1'")).one()
+
+        assert wrote is True
+        assert tuple(row) == ("failure", source_error.public_message, "stored-output")
+        assert EventStore.get_events(db_url, "job-1") == []
+
+    @pytest.mark.asyncio
+    async def test_empty_source_output_encryption_failure_uses_generic_sanitized_failure(self, tmp_path):
+        from aiq_agent.common.citation_verification import EmptySourceRegistryError
+        from aiq_agent.common.citation_verification import EmptySourceRegistryReason
+        from aiq_api.jobs.crypto import ContentEncryptionUnavailable
+
+        source_error = EmptySourceRegistryError(
+            reason=EmptySourceRegistryReason.NO_SOURCE_RESULTS,
+            generated_answer="plaintext report must not be persisted",
+        )
+        serialize_output = MagicMock(side_effect=ContentEncryptionUnavailable("secret backend details"))
+        write_failure = MagicMock()
+        write_fallback = MagicMock(return_value=False)
+        event_store = MagicMock()
+
+        with (
+            patch("aiq_api.jobs.crypto.serialize_job_output_for_storage", serialize_output),
+            patch(
+                "aiq_api.jobs.runner._write_job_source_failure_if_running_sync",
+                write_failure,
+            ),
+            patch("aiq_api.jobs.runner._write_job_failure_if_running_sync", write_fallback),
+        ):
+            # Exercise the same terminal helper path directly; full worker setup is
+            # covered by the parameterized test above.
+            from aiq_api.jobs.runner import _persist_empty_source_failure
+
+            wrote = await _persist_empty_source_failure(
+                error=source_error,
+                job_output_cipher=object(),
+                db_url=f"sqlite:///{tmp_path / 'test.db'}",
+                job_id="job-1",
+                event_store=event_store,
+            )
+
+        write_failure.assert_not_called()
+        assert wrote is False
+        write_failure.assert_not_called()
+        write_fallback.assert_called_once_with(
+            f"sqlite:///{tmp_path / 'test.db'}",
+            "job-1",
+            "job failed (ContentEncryptionUnavailable); check server logs for details",
+        )
+        event_store.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("terminal_status", ["success", "failure", "interrupted"])
+    async def test_source_failure_fallback_does_not_overwrite_terminal_race(self, tmp_path, terminal_status):
+        from sqlalchemy import text
+
+        from aiq_agent.common.citation_verification import EmptySourceRegistryError
+        from aiq_api.jobs.event_store import EventStore
+        from aiq_api.jobs.runner import _persist_empty_source_failure
+
+        db_url = f"sqlite:///{tmp_path / 'fallback-race.db'}"
+        engine = EventStore._get_or_create_sync_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE job_info (job_id TEXT PRIMARY KEY, status TEXT, error TEXT, "
+                    "output TEXT, updated_at TIMESTAMP)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO job_info (job_id, status, error, output) VALUES ('job-1', :status, 'original', 'kept')"
+                ),
+                {"status": terminal_status},
+            )
+
+        with patch(
+            "aiq_api.jobs.crypto.serialize_job_output_for_storage",
+            side_effect=RuntimeError("persistence failed"),
+        ):
+            wrote = await _persist_empty_source_failure(
+                error=EmptySourceRegistryError(generated_answer="plaintext"),
+                job_output_cipher=object(),
+                db_url=db_url,
+                job_id="job-1",
+            )
+
+        with engine.connect() as conn:
+            row = conn.execute(text("SELECT status, error, output FROM job_info WHERE job_id = 'job-1'")).one()
+
+        assert wrote is False
+        assert tuple(row) == (terminal_status, "original", "kept")
+
+    def test_source_failure_write_only_changes_running_job(self, tmp_path):
+        from sqlalchemy import text
+
+        from aiq_api.jobs.event_store import EventStore
+        from aiq_api.jobs.runner import _write_job_source_failure_if_running_sync
+
+        db_url = f"sqlite:///{tmp_path / 'jobs.db'}"
+        engine = EventStore._get_or_create_sync_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE job_info (job_id TEXT PRIMARY KEY, status TEXT, error TEXT, "
+                    "output TEXT, updated_at TIMESTAMP)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO job_info (job_id, status, error, output) VALUES "
+                    "('running-job', 'running', NULL, NULL), "
+                    "('terminal-job', 'success', NULL, 'original')"
+                )
+            )
+
+        assert _write_job_source_failure_if_running_sync(db_url, "running-job", "Select a source.", "encrypted-output")
+        assert not _write_job_source_failure_if_running_sync(db_url, "terminal-job", "Select a source.", "replacement")
+
+        with engine.connect() as conn:
+            running = conn.execute(
+                text("SELECT status, error, output FROM job_info WHERE job_id = 'running-job'")
+            ).one()
+            terminal = conn.execute(
+                text("SELECT status, error, output FROM job_info WHERE job_id = 'terminal-job'")
+            ).one()
+        assert tuple(running) == ("failure", "Select a source.", "encrypted-output")
+        assert tuple(terminal) == ("success", None, "original")
 
 
 class TestEventStore:
@@ -2169,6 +2491,56 @@ class TestAsyncJobRunnerAgentFactory:
         assert agent.max_research_concurrency == 2
         assert agent.max_concurrent_source_tool_calls == 3
         assert agent.max_source_tool_batch_size == 4
+
+    @pytest.mark.asyncio
+    async def test_async_deep_researcher_rejects_empty_sources_when_citation_verification_disabled(self):
+        """The worker path enforces source selection even when citation verification is disabled."""
+        from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_agent.common import LLMProvider
+        from aiq_agent.common.citation_verification import EmptySourceRegistryError
+        from aiq_agent.common.citation_verification import EmptySourceRegistryReason
+        from aiq_api.jobs.runner import _create_agent_instance
+        from aiq_api.jobs.runner import _run_agent
+
+        class FakeMonitor:
+            is_cancelled = False
+
+            def start(self):
+                return None
+
+            def stop(self):
+                return None
+
+        mock_llm = MagicMock()
+        provider = LLMProvider()
+        provider.set_default(mock_llm)
+        agent = _create_agent_instance(
+            agent_cls=DeepResearcherAgent,
+            llm_provider=provider,
+            llm=mock_llm,
+            tools=[],
+            fn_config=DeepResearchAgentConfig(
+                orchestrator_llm="llm",
+                enable_citation_verification=False,
+            ),
+            verbose=False,
+            callbacks=[],
+            job_id="async-job-123",
+        )
+
+        with patch.object(agent, "_build_orchestrator_agent") as build_orchestrator:
+            with pytest.raises(EmptySourceRegistryError) as exc_info:
+                await _run_agent(
+                    agent=agent,
+                    input_text="Research this",
+                    monitor=FakeMonitor(),
+                    data_sources=[],
+                )
+
+        assert agent.enable_citation_verification is False
+        assert exc_info.value.reason is EmptySourceRegistryReason.NO_SOURCES_SELECTED
+        build_orchestrator.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_run_agent_seeds_initial_files_when_state_supports_files(self):


### PR DESCRIPTION
## Summary

Backports #397 to release/2.2, including actionable empty-source outcomes, safe async failure persistence, regression coverage, and artifact workflow documentation.

## Verification

- Focused tests: 1,032 passed, 6 skipped
- Ruff lint passed
- Ruff format passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Research now returns consistent, actionable messaging for empty, unselected, unavailable, or no-results source conditions, including the relevant draft when available.
  * Async job status surfaces typed source-condition failures, and preserved reports remain accessible on failure.
  * Final report content is now emitted reliably as an output artifact for async flows.
* **Documentation**
  * Updated the skills sandbox example to clarify persistence behavior.
  * Expanded REST API documentation for typed source-condition failures and report preservation.
* **Tests**
  * Added and extended coverage for empty-source scenarios and async job status/report handling.
* **Chores**
  * Updated link-check configuration to ignore an additional API reference URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->