### PR TITLE
fix(knowledge_layer): use source metadata description

### DIFF
--- a/sources/knowledge_layer/src/foundational_rag/adapter.py
+++ b/sources/knowledge_layer/src/foundational_rag/adapter.py
@@ -491,6 +491,14 @@ class FoundationalRagRetriever(BaseRetriever):
         metadata = result.get("metadata") or {}
         content_metadata = metadata.get("content_metadata") or {}
 
+        # For FRAG table/image chunks the raw content field is base64-encoded binary.
+        # Use the human-readable description from metadata when present.
+        description = metadata.get("description")
+        if isinstance(description, str) and description:
+            content = description
+        elif not isinstance(content, str):
+            content = ""
+
         # Strip temp file prefix (tmp + 8 random chars + _) for display; keep raw for delete ops
         display_name = re.sub(r"^tmp.{8}_", "", document_name_raw)
 


### PR DESCRIPTION
#### Overview

Backports #392 to `release/2.2`.

PR #392 was inadvertently merged directly into `develop`. Because changes from
`release/2.2` are forward-merged into `develop`, this PR applies the same fix to
the release branch. No revert on `develop` is required.

This is an exact backport with no functional changes relative to #392.

#### DCO sign-off for the squash commit

Signed-off-by: Ajay Thorve <20476096+AjayThorve@users.noreply.github.com>

#### Validation

- [x] The squash commit from #392 cherry-picked cleanly onto the latest `origin/release/2.2`.
- [x] `git diff --check` passed.
- [x] The resulting forward merge into current `develop` was verified to be clean and content-neutral.
- [ ] Branch CI completed successfully.
- [x] Tests and documentation are unchanged because this is an exact backport of #392.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin.

#### Where should reviewers start?

`sources/knowledge_layer/src/foundational_rag/adapter.py`

#### Related Issues

- Backports #392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of table and image search results with binary content.
  * Displays available descriptions instead of unreadable encoded data.
  * Prevents binary content from appearing as invalid text when no description is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->