### PR TITLE
fix: stabilize research runtime

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
   lint:
     name: UI Lint
     runs-on: ubuntu-latest

--- a/configs/config_web_default_guardrails.yml
+++ b/configs/config_web_default_guardrails.yml
@@ -98,9 +98,11 @@ middleware:
           regex_detection:
             input:
               patterns:
-                - '(?i)\b(?:ignore|disregard|discard|override)\s+(?:(?:all|any|the)\s+)?(?:previous|prior|earlier)\s+instructions?\b'
-                - '(?i)reveal\s+(the\s+)?system\s+prompt'
-                - '(?i)\b(?:api[\s_-]*key|password)\s*(?::|=|\bis\b|\bequals?\b)\s*\S+'
+                # Shared by the workflow and direct research-agent boundaries so
+                # endpoint choice cannot bypass the baseline input policy.
+                - &prompt_override_pattern '(?i)\b(?:ignore|disregard|discard|override)\s+(?:(?:all|any|the)\s+)?(?:previous|prior|earlier)\s+instructions?\b'
+                - &system_prompt_pattern '(?i)reveal\s+(the\s+)?system\s+prompt'
+                - &secret_assignment_pattern '(?i)\b(?:api[\s_-]*key|password)\s*(?::|=|\bis\b|\bequals?\b)\s*\S+'
             output:
               patterns:
                 - '(?i)system\s+prompt\s*[:=]'
@@ -132,6 +134,9 @@ middleware:
           regex_detection:
             input:
               patterns:
+                - *prompt_override_pattern
+                - *system_prompt_pattern
+                - *secret_assignment_pattern
                 - '(?i)reveal\s+(the\s+)?tool\s+credentials'
                 - '(?i)show\s+(me\s+)?(your\s+)?tool\s+configuration'
             output:
@@ -165,6 +170,9 @@ middleware:
           regex_detection:
             input:
               patterns:
+                - *prompt_override_pattern
+                - *system_prompt_pattern
+                - *secret_assignment_pattern
                 - '(?i)dump\s+(all\s+)?documents'
                 - '(?i)exfiltrate\s+(the\s+)?knowledge\s+base'
             output:

--- a/frontends/ui/package-lock.json
+++ b/frontends/ui/package-lock.json
@@ -156,6 +156,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -510,6 +511,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -532,6 +534,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -555,9 +558,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1270,9 +1273,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1280,9 +1283,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1292,19 +1295,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1314,19 +1317,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1340,9 +1362,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1356,9 +1378,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -1372,9 +1394,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -1388,9 +1410,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -1404,9 +1426,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -1420,9 +1442,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -1436,9 +1458,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -1452,9 +1474,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1468,9 +1490,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -1484,9 +1506,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -1496,19 +1518,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1518,19 +1540,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -1540,19 +1562,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1562,19 +1584,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -1584,19 +1606,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -1606,19 +1628,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -1628,19 +1650,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -1650,38 +1672,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1691,16 +1729,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1710,16 +1748,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1729,7 +1767,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1987,9 +2025,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2005,9 +2040,6 @@
       "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2025,9 +2057,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2043,9 +2072,6 @@
       "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4724,8 +4750,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4894,6 +4919,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4905,6 +4931,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4998,6 +5025,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -5700,6 +5728,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6194,6 +6223,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6849,8 +6879,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.12",
@@ -7176,6 +7205,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7361,6 +7391,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9715,7 +9746,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11457,6 +11487,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -11477,6 +11508,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
       "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -11516,6 +11548,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11607,7 +11640,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11623,7 +11655,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11779,6 +11810,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11822,6 +11854,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11844,8 +11877,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -12435,54 +12467,59 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -13089,6 +13126,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13332,6 +13370,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13691,6 +13730,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -13798,6 +13838,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13811,6 +13852,7 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -14223,6 +14265,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontends/ui/package.json
+++ b/frontends/ui/package.json
@@ -67,6 +67,7 @@
     ]
   },
   "overrides": {
-    "postcss": "^8.5.23"
+    "postcss": "^8.5.23",
+    "sharp": "^0.35.3"
   }
 }

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -301,7 +301,10 @@ class DeepResearcherAgent:
             logger.info("Query: %s...", query[:100])
             logger.info("=" * 80)
 
-        budget_token = activate_source_tool_budget(self.resource_limits.max_source_tool_calls)
+        budget_token = activate_source_tool_budget(
+            self.resource_limits.max_source_tool_calls,
+            max_consecutive_failures=self.resource_limits.max_consecutive_source_tool_failures,
+        )
         try:
             execution_timeout = asyncio.timeout(self.resource_limits.max_execution_seconds)
             try:

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -57,6 +57,7 @@ _SOURCE_ROUTING_PATH = "/shared/source_routing.json"
 _SOURCE_ROUTING_STATE_KEYS = (_SOURCE_ROUTING_PATH, "/source_routing.json")
 FINAL_REPORT_PATH = "/shared/output.md"
 FINAL_REPORT_STATE_PATHS = (FINAL_REPORT_PATH, "/output.md")
+_GENERATED_RETRY_MARKER = "aiq_generated_retry"
 _UNRESOLVED_SANDBOX_PATH_PATTERN = re.compile(
     r"<\s*sandbox_(?:artifact_dir|workdir)\s*>|\{\{\s*sandbox_(?:artifact_dir|workdir)\s*\}\}"
 )
@@ -573,7 +574,11 @@ class RequiredOutputFileMiddleware(AgentMiddleware):
         return self.tracker.committed_text(files, paths=self.paths) is not None
 
     def _retry_count(self, messages: list[object]) -> int:
-        return sum(isinstance(message, HumanMessage) and message.content == self._retry_message for message in messages)
+        return sum(
+            isinstance(message, HumanMessage)
+            and message.additional_kwargs.get(_GENERATED_RETRY_MARKER) == "required_output_file"
+            for message in messages
+        )
 
     def _check_after_model(self, state: object) -> dict[str, object] | None:
         messages = state.get("messages", []) if isinstance(state, dict) else getattr(state, "messages", [])
@@ -593,7 +598,12 @@ class RequiredOutputFileMiddleware(AgentMiddleware):
 
         logger.warning("Agent reported completion before committing the required output; requesting corrective turn")
         return {
-            "messages": [HumanMessage(content=self._retry_message)],
+            "messages": [
+                HumanMessage(
+                    content=self._retry_message,
+                    additional_kwargs={_GENERATED_RETRY_MARKER: "required_output_file"},
+                )
+            ],
             "jump_to": "model",
         }
 
@@ -638,7 +648,11 @@ class RequiredWriterDelegationMiddleware(AgentMiddleware):
         )
 
     def _retry_count(self, messages: list[object]) -> int:
-        return sum(isinstance(message, HumanMessage) and message.content == self._retry_message for message in messages)
+        return sum(
+            isinstance(message, HumanMessage)
+            and message.additional_kwargs.get(_GENERATED_RETRY_MARKER) == "required_writer_delegation"
+            for message in messages
+        )
 
     def _check_after_model(self, state: object) -> dict[str, object] | None:
         messages = state.get("messages", []) if isinstance(state, dict) else getattr(state, "messages", [])
@@ -654,7 +668,15 @@ class RequiredWriterDelegationMiddleware(AgentMiddleware):
             raise RuntimeError(self.reason_code)
 
         logger.warning("Orchestrator ended before writer delegation; requesting one corrective turn")
-        return {"messages": [HumanMessage(content=self._retry_message)], "jump_to": "model"}
+        return {
+            "messages": [
+                HumanMessage(
+                    content=self._retry_message,
+                    additional_kwargs={_GENERATED_RETRY_MARKER: "required_writer_delegation"},
+                )
+            ],
+            "jump_to": "model",
+        }
 
     @hook_config(can_jump_to=["model"])
     def after_model(self, state, runtime):

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -608,6 +608,65 @@ class RequiredOutputFileMiddleware(AgentMiddleware):
         return self._check_after_model(state)
 
 
+class RequiredWriterDelegationMiddleware(AgentMiddleware):
+    """Prevent the orchestrator from terminating before writer-owned publication.
+
+    Source failures can make an orchestrator conclude that no further research
+    is useful and return ordinary assistant text without ever delegating to the
+    writer. Give it one bounded corrective turn that forbids more research and
+    requires writer delegation. The writer's existing commit middleware remains
+    the only component allowed to publish the final report.
+    """
+
+    def __init__(
+        self,
+        *,
+        tracker: FinalReportCommitTracker,
+        max_retries: int = 1,
+        reason_code: str = "writer_output_not_committed",
+    ) -> None:
+        if max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+        self.tracker = tracker
+        self.max_retries = max_retries
+        self.reason_code = reason_code
+        self._retry_message = (
+            "The run cannot finish because writer-agent has not committed /shared/output.md. "
+            "Do not perform or retry source research. Delegate to writer-agent now using the Writer Delegation "
+            "Template and the plan, research notes, verified sources, and explicit evidence gaps already available. "
+            "After writer-agent returns, return only its completion marker."
+        )
+
+    def _retry_count(self, messages: list[object]) -> int:
+        return sum(isinstance(message, HumanMessage) and message.content == self._retry_message for message in messages)
+
+    def _check_after_model(self, state: object) -> dict[str, object] | None:
+        messages = state.get("messages", []) if isinstance(state, dict) else getattr(state, "messages", [])
+        files = state.get("files", {}) if isinstance(state, dict) else getattr(state, "files", {})
+        if not isinstance(messages, list) or not messages:
+            return None
+        last_message = messages[-1]
+        if not isinstance(last_message, AIMessage) or last_message.tool_calls:
+            return None
+        if self.tracker.committed_text(files, paths=FINAL_REPORT_STATE_PATHS) is not None:
+            return None
+        if self._retry_count(messages) >= self.max_retries:
+            raise RuntimeError(self.reason_code)
+
+        logger.warning("Orchestrator ended before writer delegation; requesting one corrective turn")
+        return {"messages": [HumanMessage(content=self._retry_message)], "jump_to": "model"}
+
+    @hook_config(can_jump_to=["model"])
+    def after_model(self, state, runtime):
+        """Require a synchronous orchestrator to delegate writer publication."""
+        return self._check_after_model(state)
+
+    @hook_config(can_jump_to=["model"])
+    async def aafter_model(self, state, runtime):
+        """Require an asynchronous orchestrator to delegate writer publication."""
+        return self._check_after_model(state)
+
+
 # Common hallucinated tool name mappings
 _TOOL_NAME_ALIASES: dict[str, str] = {
     "open_file": "read_file",

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -41,6 +41,7 @@ from aiq_agent.common import render_prompt_template
 from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import SourceRegistry
 from aiq_agent.common.citation_verification import extract_sources_from_tool_result
+from aiq_agent.common.citation_verification import is_non_citable_status_output
 
 from .resource_limits import DeepResearchResourceLimits
 from .resource_limits import StateBudgetLedger
@@ -1065,10 +1066,13 @@ class SourceRegistryMiddleware(AgentMiddleware):
                 tool_name = request.tool_call.get("name", "")
             if tool_name not in self._source_tool_names:
                 return result
+            content = str(result.content)
+            if is_non_citable_status_output(content):
+                return result
             source_id = get_source_id_for_tool(tool_name)
             sources = extract_sources_from_tool_result(
                 tool_name,
-                str(result.content),
+                content,
                 source_id=source_id,
                 result_status=getattr(result, "status", None),
             )

--- a/src/aiq_agent/agents/deep_researcher/factory.py
+++ b/src/aiq_agent/agents/deep_researcher/factory.py
@@ -50,6 +50,7 @@ from .custom_middleware import FinalReportCommitTracker
 from .custom_middleware import FinalReportOwnershipGuardMiddleware
 from .custom_middleware import PlanPersistenceMiddleware
 from .custom_middleware import RequiredOutputFileMiddleware
+from .custom_middleware import RequiredWriterDelegationMiddleware
 from .custom_middleware import SourceRegistryMiddleware
 from .custom_middleware import SourceRoutingGuardMiddleware
 from .custom_middleware import SourceRoutingPersistenceMiddleware
@@ -659,6 +660,7 @@ def build_deep_research_graph(
                     sandbox_enabled=context.runtime.execution_enabled,
                 ),
                 TodoQuotaMiddleware(resource_limits=context.resource_limits),
+                RequiredWriterDelegationMiddleware(tracker=context.final_report_tracker),
             ]
         ),
         permissions=context.permissions(ORCHESTRATOR_AGENT),

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -115,6 +115,7 @@ The planner will use search tools to discover internal vs external and what info
 - Keep a submitted-query ledger using each ResearchQuery's exact `query` string. Before any later call, remove queries already submitted and successfully returned. Never repeat a covered query for extra depth.
 - `run_research_batch` returns a JSON array of successful `ResearchNotes` and persists those same notes as JSON files under `/shared/`; each note includes its own `evidence_judgment`.
 - If `run_research_batch` returns a tool error, read the error, revise only the invalid, failed, or missing ResearchQuery objects, and call `run_research_batch` again for that missing research. Do not resubmit successful returned notes.
+- If the error says the source-tool circuit is open or a source/query budget is exhausted, do not retry research. Proceed immediately to writer-agent with the successful notes and verified sources already available, and require the writer to state material evidence gaps. If no evidence was recovered, still delegate once so the runtime can return the existing actionable insufficient-sources outcome with a writer-produced draft; never claim a fully researched result.
 - Do NOT pass query IDs — each ResearchQuery needs full context.
 - Before writing, use the ResearchNotes returned by `run_research_batch` and the research note files under `/shared/` as the research evidence.
 

--- a/src/aiq_agent/agents/deep_researcher/resource_limits.py
+++ b/src/aiq_agent/agents/deep_researcher/resource_limits.py
@@ -27,6 +27,7 @@ DEFAULT_MAX_RESEARCH_QUERY_CHARS = 10_000
 DEFAULT_MAX_RESEARCH_NOTE_BYTES = 512 * 1024
 DEFAULT_MAX_TOTAL_RESEARCH_NOTE_BYTES = 10 * 1024 * 1024
 DEFAULT_MAX_SOURCE_TOOL_CALLS = 100
+DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES = 8
 DEFAULT_MAX_TODO_ITEMS = 20
 DEFAULT_MAX_TODO_ITEM_CHARS = 2048
 DEFAULT_MAX_TOTAL_TODO_CHARS = 10_000
@@ -272,6 +273,12 @@ class DeepResearchResourceLimits(BaseModel):
         ge=1,
         le=DEFAULT_MAX_SOURCE_TOOL_CALLS,
         description="Maximum AI-Q source-tool attempts and concrete batch items in one job.",
+    )
+    max_consecutive_source_tool_failures: int = Field(
+        default=DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES,
+        ge=1,
+        le=DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES,
+        description="Consecutive failed source-tool results allowed before the per-job circuit opens.",
     )
     max_todo_items: int = Field(
         default=DEFAULT_MAX_TODO_ITEMS,

--- a/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
@@ -116,9 +116,7 @@ class SourceToolCallBudget:
         failed = source_tool_result_failed(result)
         async with self._lock:
             if self.circuit_open:
-                raise SourceToolCircuitOpen(
-                    f"Source-tool circuit is open after {self.consecutive_failures} consecutive provider failures"
-                )
+                return
             if not failed:
                 self.consecutive_failures = 0
                 return

--- a/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
@@ -64,7 +64,7 @@ def source_tool_result_failed(result: object) -> bool:
         return True
     if getattr(result, "status", None) == "error":
         return True
-    text = json.dumps(result) if isinstance(result, dict) else str(result)
+    text = json.dumps(result, default=str) if isinstance(result, dict) else str(result)
     text = text.strip()
     if not text:
         return True
@@ -320,7 +320,7 @@ def _make_throttled_source_tool(
                 raise
             except Exception:
                 await _record_source_tool_result(None)
-                raise
+                return _SOURCE_TOOL_FAILURE_OUTPUT
             await _record_source_tool_result(result)
             if source_tool_result_failed(result):
                 return _SOURCE_TOOL_FAILURE_OUTPUT

--- a/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
@@ -40,6 +40,7 @@ from ..resource_limits import DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES
 DEFAULT_MAX_CONCURRENT_SOURCE_TOOL_CALLS = 5
 DEFAULT_MAX_SOURCE_TOOL_BATCH_SIZE = 4
 DEFAULT_SOURCE_TOOL_CONCURRENCY_TIMEOUT = 120.0
+_SOURCE_TOOL_FAILURE_OUTPUT = "ERROR: Source batch returned no citable results."
 
 
 class SourceToolBudgetExceeded(RuntimeError):
@@ -243,7 +244,7 @@ def _format_batch_tool_output(results: list[tuple[str, str | None, str | None]])
         if error is None and output:
             parts.append(f"## Query: {query}\n{output}")
     if not parts:
-        return "ERROR: Source batch returned no citable results."
+        return _SOURCE_TOOL_FAILURE_OUTPUT
     return "\n\n---\n\n".join(parts)
 
 
@@ -321,6 +322,8 @@ def _make_throttled_source_tool(
                 await _record_source_tool_result(None)
                 raise
             await _record_source_tool_result(result)
+            if source_tool_result_failed(result):
+                return _SOURCE_TOOL_FAILURE_OUTPUT
         return result
 
     # Retain injected fields for runtime validation/forwarding. BaseTool derives

--- a/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
@@ -270,9 +270,9 @@ def _make_batch_source_tool(
                     result = await original_tool.ainvoke({input_field_name: query})
                 except SourceToolCircuitOpen:
                     raise
-                except Exception as exc:  # noqa: BLE001 - represented as per-item failure for the LLM
+                except Exception:  # noqa: BLE001 - represented as per-item failure for the LLM
                     await _record_source_tool_result(None)
-                    return query, None, str(exc)
+                    return query, None, "Source request failed."
                 await _record_source_tool_result(result)
             return query, str(result), None
 

--- a/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
@@ -59,6 +59,8 @@ def source_tool_result_failed(result: object) -> bool:
     """
     if result is None:
         return True
+    if isinstance(result, (dict, list)) and not result:
+        return True
     if getattr(result, "status", None) == "error":
         return True
     text = json.dumps(result) if isinstance(result, dict) else str(result)
@@ -100,6 +102,14 @@ class SourceToolCallBudget:
                     f"Source-tool call budget exhausted ({self.used_calls}/{self.max_calls} calls used)"
                 )
             self.used_calls += count
+
+    async def ensure_circuit_closed(self) -> None:
+        """Reject a queued invocation if an earlier provider call opened the circuit."""
+        async with self._lock:
+            if self.circuit_open:
+                raise SourceToolCircuitOpen(
+                    f"Source-tool circuit is open after {self.consecutive_failures} consecutive provider failures"
+                )
 
     async def record_result(self, result: object) -> None:
         """Update consecutive-failure state and open the circuit when exhausted."""
@@ -149,6 +159,12 @@ async def _record_source_tool_result(result: object) -> None:
     budget = _source_tool_budget.get()
     if budget is not None:
         await budget.record_result(result)
+
+
+async def _ensure_source_tool_circuit_closed() -> None:
+    budget = _source_tool_budget.get()
+    if budget is not None:
+        await budget.ensure_circuit_closed()
 
 
 class SourceToolConcurrencyLimiter:
@@ -248,13 +264,17 @@ def _make_batch_source_tool(
         await _consume_source_tool_budget(len(query_list))
 
         async def _call_one(query: str) -> tuple[str, str | None, str | None]:
-            try:
-                async with limiter.limit():
+            async with limiter.limit():
+                await _ensure_source_tool_circuit_closed()
+                try:
                     result = await original_tool.ainvoke({input_field_name: query})
+                except SourceToolCircuitOpen:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - represented as per-item failure for the LLM
+                    await _record_source_tool_result(None)
+                    return query, None, str(exc)
                 await _record_source_tool_result(result)
-                return query, str(result), None
-            except Exception as exc:  # noqa: BLE001 - represented as per-item failure for the LLM
-                return query, None, str(exc)
+            return query, str(result), None
 
         results = await asyncio.gather(*(_call_one(query) for query in query_list))
         return _format_batch_tool_output(results)
@@ -282,8 +302,15 @@ def _make_throttled_source_tool(
     async def _run_throttled(**kwargs) -> object:
         await _consume_source_tool_budget()
         async with limiter.limit():
-            result = await original_tool.ainvoke(kwargs)
-        await _record_source_tool_result(result)
+            await _ensure_source_tool_circuit_closed()
+            try:
+                result = await original_tool.ainvoke(kwargs)
+            except SourceToolCircuitOpen:
+                raise
+            except Exception:
+                await _record_source_tool_result(None)
+                raise
+            await _record_source_tool_result(result)
         return result
 
     # Retain injected fields for runtime validation/forwarding. BaseTool derives

--- a/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import weakref
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -32,6 +33,10 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from aiq_agent.common.citation_verification import is_non_citable_status_output
+
+from ..resource_limits import DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES
+
 DEFAULT_MAX_CONCURRENT_SOURCE_TOOL_CALLS = 5
 DEFAULT_MAX_SOURCE_TOOL_BATCH_SIZE = 4
 DEFAULT_SOURCE_TOOL_CONCURRENCY_TIMEOUT = 120.0
@@ -41,17 +46,44 @@ class SourceToolBudgetExceeded(RuntimeError):
     """Raised before an external call would exceed the per-job budget."""
 
 
+class SourceToolCircuitOpen(RuntimeError):
+    """Raised when a provider failure wave opens the per-job source circuit."""
+
+
+def source_tool_result_failed(result: object) -> bool:
+    """Return whether a source result is provider status rather than evidence.
+
+    The classifier is deliberately conservative: it recognizes whole-result
+    error/status shapes and leading provider errors, but does not treat an
+    arbitrary article mentioning an HTTP error as a failed tool call.
+    """
+    if result is None:
+        return True
+    if getattr(result, "status", None) == "error":
+        return True
+    text = json.dumps(result) if isinstance(result, dict) else str(result)
+    text = text.strip()
+    if not text:
+        return True
+    return is_non_citable_status_output(text)
+
+
 @dataclass
 class SourceToolCallBudget:
     """Concurrency-safe per-job counter inherited by nested researcher tasks."""
 
     max_calls: int
+    max_consecutive_failures: int = DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES
     used_calls: int = 0
+    consecutive_failures: int = 0
+    circuit_open: bool = False
     _lock: asyncio.Lock = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.max_calls < 1:
             raise ValueError("max_calls must be >= 1")
+        if self.max_consecutive_failures < 1:
+            raise ValueError("max_consecutive_failures must be >= 1")
         self._lock = asyncio.Lock()
 
     async def consume(self, count: int = 1) -> None:
@@ -59,11 +91,30 @@ class SourceToolCallBudget:
         if count < 1:
             raise ValueError("count must be >= 1")
         async with self._lock:
+            if self.circuit_open:
+                raise SourceToolCircuitOpen(
+                    f"Source-tool circuit is open after {self.consecutive_failures} consecutive provider failures"
+                )
             if self.used_calls + count > self.max_calls:
                 raise SourceToolBudgetExceeded(
                     f"Source-tool call budget exhausted ({self.used_calls}/{self.max_calls} calls used)"
                 )
             self.used_calls += count
+
+    async def record_result(self, result: object) -> None:
+        """Update consecutive-failure state and open the circuit when exhausted."""
+        failed = source_tool_result_failed(result)
+        async with self._lock:
+            if not failed:
+                self.consecutive_failures = 0
+                return
+
+            self.consecutive_failures += 1
+            if self.consecutive_failures >= self.max_consecutive_failures:
+                self.circuit_open = True
+                raise SourceToolCircuitOpen(
+                    f"Source-tool circuit opened after {self.consecutive_failures} consecutive provider failures"
+                )
 
 
 _source_tool_budget: ContextVar[SourceToolCallBudget | None] = ContextVar(
@@ -72,9 +123,15 @@ _source_tool_budget: ContextVar[SourceToolCallBudget | None] = ContextVar(
 )
 
 
-def activate_source_tool_budget(max_calls: int) -> Token[SourceToolCallBudget | None]:
+def activate_source_tool_budget(
+    max_calls: int,
+    *,
+    max_consecutive_failures: int = DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES,
+) -> Token[SourceToolCallBudget | None]:
     """Install a fresh budget for one deep-research run."""
-    return _source_tool_budget.set(SourceToolCallBudget(max_calls=max_calls))
+    return _source_tool_budget.set(
+        SourceToolCallBudget(max_calls=max_calls, max_consecutive_failures=max_consecutive_failures)
+    )
 
 
 def reset_source_tool_budget(token: Token[SourceToolCallBudget | None]) -> None:
@@ -86,6 +143,12 @@ async def _consume_source_tool_budget(count: int = 1) -> None:
     budget = _source_tool_budget.get()
     if budget is not None:
         await budget.consume(count)
+
+
+async def _record_source_tool_result(result: object) -> None:
+    budget = _source_tool_budget.get()
+    if budget is not None:
+        await budget.record_result(result)
 
 
 class SourceToolConcurrencyLimiter:
@@ -188,6 +251,7 @@ def _make_batch_source_tool(
             try:
                 async with limiter.limit():
                     result = await original_tool.ainvoke({input_field_name: query})
+                await _record_source_tool_result(result)
                 return query, str(result), None
             except Exception as exc:  # noqa: BLE001 - represented as per-item failure for the LLM
                 return query, None, str(exc)
@@ -219,6 +283,7 @@ def _make_throttled_source_tool(
         await _consume_source_tool_budget()
         async with limiter.limit():
             result = await original_tool.ainvoke(kwargs)
+        await _record_source_tool_result(result)
         return result
 
     # Retain injected fields for runtime validation/forwarding. BaseTool derives

--- a/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/source_tool_batching.py
@@ -115,6 +115,10 @@ class SourceToolCallBudget:
         """Update consecutive-failure state and open the circuit when exhausted."""
         failed = source_tool_result_failed(result)
         async with self._lock:
+            if self.circuit_open:
+                raise SourceToolCircuitOpen(
+                    f"Source-tool circuit is open after {self.consecutive_failures} consecutive provider failures"
+                )
             if not failed:
                 self.consecutive_failures = 0
                 return
@@ -235,11 +239,13 @@ def _single_string_input_field(tool: BaseTool) -> str | None:
 
 
 def _format_batch_tool_output(results: list[tuple[str, str | None, str | None]]) -> str:
-    """Render grouped per-input output without hiding partial failures."""
+    """Render successful evidence without making failed-only batches citable."""
     parts: list[str] = []
     for query, output, error in results:
-        body = f"ERROR: {error}" if error else (output or "")
-        parts.append(f"## Query: {query}\n{body}")
+        if error is None and output:
+            parts.append(f"## Query: {query}\n{output}")
+    if not parts:
+        return "ERROR: Source batch returned no citable results."
     return "\n\n---\n\n".join(parts)
 
 
@@ -264,17 +270,23 @@ def _make_batch_source_tool(
         await _consume_source_tool_budget(len(query_list))
 
         async def _call_one(query: str) -> tuple[str, str | None, str | None]:
-            async with limiter.limit():
-                await _ensure_source_tool_circuit_closed()
-                try:
-                    result = await original_tool.ainvoke({input_field_name: query})
-                except SourceToolCircuitOpen:
-                    raise
-                except Exception:  # noqa: BLE001 - represented as per-item failure for the LLM
-                    await _record_source_tool_result(None)
+            try:
+                async with limiter.limit():
+                    await _ensure_source_tool_circuit_closed()
+                    try:
+                        result = await original_tool.ainvoke({input_field_name: query})
+                    except SourceToolCircuitOpen:
+                        raise
+                    except Exception:  # noqa: BLE001 - represented as per-item failure for the LLM
+                        await _record_source_tool_result(None)
+                        return query, None, "Source request failed."
+                    failed = source_tool_result_failed(result)
+                    await _record_source_tool_result(result)
+                if failed:
                     return query, None, "Source request failed."
-                await _record_source_tool_result(result)
-            return query, str(result), None
+                return query, str(result), None
+            except SourceToolCircuitOpen:
+                return query, None, "Source request skipped because the source circuit is open."
 
         results = await asyncio.gather(*(_call_one(query) for query in query_list))
         return _format_batch_tool_output(results)

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -526,7 +526,7 @@ def extract_sources_from_tool_result(
     # Reject provider/status payloads before running source parsers. Error
     # responses can contain documentation or request URLs, but those URLs are
     # diagnostics rather than evidence and must not satisfy citation checks.
-    if result_status == "error" or _is_non_citable_status_output(content):
+    if result_status == "error" or is_non_citable_status_output(content):
         return []
 
     name_lower = tool_name.lower()
@@ -552,7 +552,7 @@ def extract_sources_from_tool_result(
     return []
 
 
-def _is_non_citable_status_output(content: str) -> bool:
+def is_non_citable_status_output(content: str) -> bool:
     """Return whether content is a tool status/error message, not evidence."""
     normalized = re.sub(r"\s+", " ", content.strip()).rstrip(".").lower()
     if not normalized:

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -568,6 +568,8 @@ def is_non_citable_status_output(content: str) -> bool:
             return True
         for key in ("status", "status_code", "statusCode", "http_status"):
             status = payload.get(key)
+            if isinstance(status, str) and status.strip().lower() == "error":
+                return True
             try:
                 status_code = int(status)
             except (TypeError, ValueError):

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -562,6 +562,8 @@ def is_non_citable_status_output(content: str) -> bool:
         payload = json.loads(content)
     except (json.JSONDecodeError, TypeError):
         payload = None
+    if isinstance(payload, (dict, list)) and not payload:
+        return True
     if isinstance(payload, dict):
         error = payload.get("error")
         if error not in (None, False, "", [], {}):

--- a/src/aiq_agent/guardrails/workflow/middleware.py
+++ b/src/aiq_agent/guardrails/workflow/middleware.py
@@ -191,7 +191,11 @@ class _WorkflowGuardrails(GuardrailsMixin):
             if targets:
                 return targets
 
-            for field in ("query", "message", "text"):
+            # NAT's public ``/generate`` and ``/generate/stream`` routes pass
+            # ``input_message``. Keep it at the same workflow boundary as the
+            # OpenAI-compatible route instead of letting endpoint shape decide
+            # whether input rails execute.
+            for field in ("input_message", "query", "message", "text"):
                 item = raw_input.get(field)
                 if isinstance(item, str) and item.strip():
                     return [
@@ -207,6 +211,15 @@ class _WorkflowGuardrails(GuardrailsMixin):
         targets = self._extract_messages_targets(raw_input, messages)
         if targets:
             return targets
+
+        input_message = getattr(raw_input, "input_message", None)
+        if isinstance(input_message, str) and input_message.strip():
+            return [
+                self._target_from_text(
+                    input_message,
+                    lambda new_text: self._set_attr_value(raw_input, raw_input, "input_message", new_text),
+                )
+            ]
         return []
 
     def _extract_messages_targets(

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -823,6 +823,15 @@ class TestRequiredOutputFileMiddleware:
         with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
             middleware.after_model(still_missing, None)
 
+    def test_matching_user_input_does_not_consume_corrective_retry(self) -> None:
+        middleware = RequiredOutputFileMiddleware(tracker=FinalReportCommitTracker())
+        state = self._state(messages=[HumanMessage(content=middleware._retry_message), AIMessage(content=self.marker)])
+
+        update = middleware.after_model(state, None)
+
+        assert update is not None
+        assert update["jump_to"] == "model"
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize("shared_route", [False, True])
     async def test_graph_overwrites_stale_planner_output_and_commits_writer_report(self, shared_route: bool) -> None:
@@ -944,6 +953,15 @@ class TestRequiredWriterDelegationMiddleware:
 
         with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
             middleware.after_model(state, None)
+
+    def test_matching_user_input_does_not_consume_delegation_retry(self) -> None:
+        middleware = RequiredWriterDelegationMiddleware(tracker=FinalReportCommitTracker())
+        state = self._state(messages=[HumanMessage(content=middleware._retry_message), AIMessage(content="No report.")])
+
+        update = middleware.after_model(state, None)
+
+        assert update is not None
+        assert update["jump_to"] == "model"
 
 
 class TestToolNameSanitizationMiddleware:

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -1373,6 +1373,16 @@ class TestSourceRegistryMiddleware:
         assert middleware.registry.all_sources() == []
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("content", ["{}", "[]", '{"status": "error"}'])
+    async def test_failed_structured_result_is_not_registered_as_tool_evidence(self, middleware, content: str):
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("advanced_web_search_tool")
+
+        await middleware.awrap_tool_call(request, handler)
+
+        assert middleware.registry.all_sources() == []
+
+    @pytest.mark.asyncio
     async def test_knowledge_layer_citation_key_captured(self, middleware):
         """Knowledge layer citation keys are captured via regex."""
         content = (

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -41,6 +41,7 @@ from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommit
 from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportOwnershipGuardMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import PlanPersistenceMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import RequiredOutputFileMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import RequiredWriterDelegationMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRoutingGuardMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRoutingPersistenceMiddleware
@@ -890,6 +891,59 @@ class TestRequiredOutputFileMiddleware:
                     "files": {"/shared/output.md": {"content": "# Planner prose"}},
                 }
             )
+
+
+class TestRequiredWriterDelegationMiddleware:
+    """The orchestrator gets one bounded chance to invoke the writer."""
+
+    @staticmethod
+    def _state(*, messages: list[object] | None = None, files: dict[str, object] | None = None) -> dict[str, object]:
+        return {
+            "messages": messages or [AIMessage(content="Research could not continue.")],
+            "files": files or {},
+        }
+
+    def test_terminal_orchestrator_response_requests_writer_delegation(self) -> None:
+        middleware = RequiredWriterDelegationMiddleware(tracker=FinalReportCommitTracker())
+
+        update = middleware.after_model(self._state(), None)
+
+        assert update is not None
+        assert update["jump_to"] == "model"
+        assert "writer-agent" in str(update["messages"][0].content)
+        assert "Do not perform or retry source research" in str(update["messages"][0].content)
+
+    def test_intermediate_tool_call_is_not_interrupted(self) -> None:
+        middleware = RequiredWriterDelegationMiddleware(tracker=FinalReportCommitTracker())
+        state = self._state(
+            messages=[
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "run_research_batch", "args": {}, "id": "research-1"}],
+                )
+            ]
+        )
+
+        assert middleware.after_model(state, None) is None
+
+    def test_committed_writer_output_allows_terminal_response(self) -> None:
+        tracker = FinalReportCommitTracker()
+        tracker.record("# Final report")
+        middleware = RequiredWriterDelegationMiddleware(tracker=tracker)
+        state = self._state(files={"/shared/output.md": {"content": "# Final report"}})
+
+        assert middleware.after_model(state, None) is None
+
+    def test_second_terminal_response_without_writer_fails_closed(self) -> None:
+        middleware = RequiredWriterDelegationMiddleware(tracker=FinalReportCommitTracker())
+        first = middleware.after_model(self._state(), None)
+        correction = first["messages"][0]
+        state = self._state(
+            messages=[AIMessage(content="No report."), correction, AIMessage(content="Still no report.")]
+        )
+
+        with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
+            middleware.after_model(state, None)
 
 
 class TestToolNameSanitizationMiddleware:

--- a/tests/aiq_agent/agents/deep_researcher/test_factory.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_factory.py
@@ -29,6 +29,7 @@ from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommit
 from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommitTracker
 from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportOwnershipGuardMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import RequiredOutputFileMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import RequiredWriterDelegationMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRoutingGuardMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRoutingPersistenceMiddleware
@@ -411,6 +412,10 @@ def test_graph_wires_filesystem_tool_call_guard_cross_cutting():
     )
     assert any(
         isinstance(middleware, TodoQuotaMiddleware) for middleware in create_graph.call_args.kwargs["middleware"]
+    )
+    assert any(
+        isinstance(middleware, RequiredWriterDelegationMiddleware)
+        for middleware in create_graph.call_args.kwargs["middleware"]
     )
     assert any(
         isinstance(middleware, FinalReportOwnershipGuardMiddleware)

--- a/tests/aiq_agent/agents/deep_researcher/test_resource_limits.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_resource_limits.py
@@ -6,6 +6,7 @@
 import pytest
 from pydantic import ValidationError
 
+from aiq_agent.agents.deep_researcher.resource_limits import DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES
 from aiq_agent.agents.deep_researcher.resource_limits import DEFAULT_MAX_FINAL_REPORT_BYTES
 from aiq_agent.agents.deep_researcher.resource_limits import DEFAULT_MAX_RESEARCH_EXECUTION_SECONDS
 from aiq_agent.agents.deep_researcher.resource_limits import DEFAULT_MAX_RESEARCH_INPUT_CHARS
@@ -43,6 +44,7 @@ def test_resource_limit_defaults_equal_non_disableable_security_ceiling():
         "max_research_note_bytes": DEFAULT_MAX_RESEARCH_NOTE_BYTES,
         "max_total_research_note_bytes": DEFAULT_MAX_TOTAL_RESEARCH_NOTE_BYTES,
         "max_source_tool_calls": DEFAULT_MAX_SOURCE_TOOL_CALLS,
+        "max_consecutive_source_tool_failures": DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES,
         "max_todo_items": DEFAULT_MAX_TODO_ITEMS,
         "max_todo_item_chars": DEFAULT_MAX_TODO_ITEM_CHARS,
         "max_total_todo_chars": DEFAULT_MAX_TOTAL_TODO_CHARS,
@@ -64,6 +66,7 @@ def test_resource_limit_defaults_equal_non_disableable_security_ceiling():
         ("max_research_note_bytes", DEFAULT_MAX_RESEARCH_NOTE_BYTES),
         ("max_total_research_note_bytes", DEFAULT_MAX_TOTAL_RESEARCH_NOTE_BYTES),
         ("max_source_tool_calls", DEFAULT_MAX_SOURCE_TOOL_CALLS),
+        ("max_consecutive_source_tool_failures", DEFAULT_MAX_CONSECUTIVE_SOURCE_TOOL_FAILURES),
         ("max_todo_items", DEFAULT_MAX_TODO_ITEMS),
         ("max_todo_item_chars", DEFAULT_MAX_TODO_ITEM_CHARS),
         ("max_total_todo_chars", DEFAULT_MAX_TOTAL_TODO_CHARS),
@@ -90,6 +93,7 @@ def test_resource_limits_accept_downward_overrides_and_are_frozen():
         max_research_note_bytes=2048,
         max_total_research_note_bytes=4096,
         max_source_tool_calls=8,
+        max_consecutive_source_tool_failures=4,
         max_todo_items=5,
         max_todo_item_chars=128,
         max_total_todo_chars=512,

--- a/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
@@ -208,6 +208,29 @@ async def test_batch_filters_structured_failures_from_citable_output(failed_resu
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failed_result",
+    ["Error: provider unavailable", {}, {"status": "error"}],
+)
+async def test_throttled_wrapper_sanitizes_classified_source_failures(failed_result: object):
+    @tool
+    async def search_tool(query: str, limit: int) -> object:
+        """Search a source with a result limit."""
+        return failed_result
+
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=1,
+        max_batch_size=1,
+    )[0]
+
+    output = await wrapped.ainvoke({"query": "query", "limit": 1})
+
+    assert output == "ERROR: Source batch returned no citable results."
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("batchable", [True, False])
 async def test_provider_exception_counts_toward_source_circuit(batchable: bool):
     calls = 0
@@ -278,7 +301,9 @@ async def test_source_failure_wave_opens_circuit_before_another_provider_call():
     token = activate_source_tool_budget(20, max_consecutive_failures=3)
     try:
         for _ in range(2):
-            assert "Error 432" in await wrapped.ainvoke({"query": "q", "limit": 1})
+            assert await wrapped.ainvoke({"query": "q", "limit": 1}) == (
+                "ERROR: Source batch returned no citable results."
+            )
         with pytest.raises(SourceToolCircuitOpen, match="opened after 3 consecutive"):
             await wrapped.ainvoke({"query": "q", "limit": 1})
         with pytest.raises(SourceToolCircuitOpen, match="circuit is open"):
@@ -305,9 +330,13 @@ async def test_successful_source_result_resets_consecutive_failure_count():
     )[0]
     token = activate_source_tool_budget(20, max_consecutive_failures=2)
     try:
-        assert "Error" in await wrapped.ainvoke({"query": "q1", "limit": 1})
+        assert await wrapped.ainvoke({"query": "q1", "limit": 1}) == (
+            "ERROR: Source batch returned no citable results."
+        )
         assert await wrapped.ainvoke({"query": "q2", "limit": 1}) == "valid evidence"
-        assert "Error" in await wrapped.ainvoke({"query": "q3", "limit": 1})
+        assert await wrapped.ainvoke({"query": "q3", "limit": 1}) == (
+            "ERROR: Source batch returned no citable results."
+        )
         with pytest.raises(SourceToolCircuitOpen, match="opened after 2 consecutive"):
             await wrapped.ainvoke({"query": "q4", "limit": 1})
     finally:

--- a/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
@@ -117,7 +117,9 @@ async def test_provider_exception_counts_toward_source_circuit(batchable: bool):
     token = activate_source_tool_budget(2, max_consecutive_failures=2)
     try:
         if batchable:
-            assert "provider timed out" in await wrapped.ainvoke(invocation)
+            output = await wrapped.ainvoke(invocation)
+            assert "Source request failed." in output
+            assert "provider timed out" not in output
         else:
             with pytest.raises(TimeoutError, match="provider timed out"):
                 await wrapped.ainvoke(invocation)
@@ -261,7 +263,8 @@ async def test_batch_wrapper_represents_partial_failures_per_item():
     assert "## Query: good" in output
     assert "ok good" in output
     assert "## Query: bad" in output
-    assert "ERROR: backend unavailable" in output
+    assert "ERROR: Source request failed." in output
+    assert "backend unavailable" not in output
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
@@ -17,6 +17,7 @@
 
 import asyncio
 from contextlib import suppress
+from datetime import datetime
 from typing import Annotated
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -50,6 +51,10 @@ from aiq_agent.agents.deep_researcher.tools.source_tool_batching import source_t
         ({}, True),
         ([], True),
         ({"status": "error"}, True),
+        ({"timestamp": datetime(2026, 8, 5)}, False),
+        ({"content": b"bytes"}, False),
+        ({"artifact": object()}, False),
+        ({"status": "error", "timestamp": datetime(2026, 8, 5)}, True),
         ("Search returned no results", True),
         ("An article explaining HTTP error 429 handling patterns.", False),
         ('<Document href="https://example.com">Evidence</Document>', False),
@@ -267,8 +272,7 @@ async def test_provider_exception_counts_toward_source_circuit(batchable: bool):
         if batchable:
             assert await wrapped.ainvoke(invocation) == "ERROR: Source batch returned no citable results."
         else:
-            with pytest.raises(TimeoutError, match="provider timed out"):
-                await wrapped.ainvoke(invocation)
+            assert await wrapped.ainvoke(invocation) == "ERROR: Source batch returned no citable results."
         if batchable:
             assert await wrapped.ainvoke(invocation) == "ERROR: Source batch returned no citable results."
         else:

--- a/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
@@ -29,10 +29,85 @@ from langchain_core.tools import tool
 
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolBudgetExceeded
+from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolCircuitOpen
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolConcurrencyLimiter
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import activate_source_tool_budget
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import adapt_source_tools_for_research
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import reset_source_tool_budget
+from aiq_agent.agents.deep_researcher.tools.source_tool_batching import source_tool_result_failed
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ("Error: provider rate limited the request", True),
+        ("Error 432: provider capacity exhausted", True),
+        ("Search failed with status 429", True),
+        ('{"status_code": 429, "detail": "rate limited"}', True),
+        ({"status": 503, "error": "unavailable"}, True),
+        ("Search returned no results", True),
+        ("An article explaining HTTP error 429 handling patterns.", False),
+        ('<Document href="https://example.com">Evidence</Document>', False),
+    ],
+)
+def test_source_tool_result_failure_classifier_is_conservative(result: object, expected: bool):
+    assert source_tool_result_failed(result) is expected
+
+
+@pytest.mark.asyncio
+async def test_source_failure_wave_opens_circuit_before_another_provider_call():
+    calls = 0
+
+    @tool
+    async def search_tool(query: str, limit: int) -> str:
+        """Search a source."""
+        nonlocal calls
+        calls += 1
+        return "Error 432: provider capacity exhausted"
+
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=1,
+        max_batch_size=1,
+    )[0]
+    token = activate_source_tool_budget(20, max_consecutive_failures=3)
+    try:
+        for _ in range(2):
+            assert "Error 432" in await wrapped.ainvoke({"query": "q", "limit": 1})
+        with pytest.raises(SourceToolCircuitOpen, match="opened after 3 consecutive"):
+            await wrapped.ainvoke({"query": "q", "limit": 1})
+        with pytest.raises(SourceToolCircuitOpen, match="circuit is open"):
+            await wrapped.ainvoke({"query": "q", "limit": 1})
+        assert calls == 3
+    finally:
+        reset_source_tool_budget(token)
+
+
+@pytest.mark.asyncio
+async def test_successful_source_result_resets_consecutive_failure_count():
+    results = iter(["Error: transient", "valid evidence", "Error: transient", "Error: transient"])
+
+    @tool
+    async def search_tool(query: str, limit: int) -> str:
+        """Search a source."""
+        return next(results)
+
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=1,
+        max_batch_size=1,
+    )[0]
+    token = activate_source_tool_budget(20, max_consecutive_failures=2)
+    try:
+        assert "Error" in await wrapped.ainvoke({"query": "q1", "limit": 1})
+        assert await wrapped.ainvoke({"query": "q2", "limit": 1}) == "valid evidence"
+        assert "Error" in await wrapped.ainvoke({"query": "q3", "limit": 1})
+        with pytest.raises(SourceToolCircuitOpen, match="opened after 2 consecutive"):
+            await wrapped.ainvoke({"query": "q4", "limit": 1})
+    finally:
+        reset_source_tool_budget(token)
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
@@ -45,6 +45,9 @@ from aiq_agent.agents.deep_researcher.tools.source_tool_batching import source_t
         ("Search failed with status 429", True),
         ('{"status_code": 429, "detail": "rate limited"}', True),
         ({"status": 503, "error": "unavailable"}, True),
+        ({}, True),
+        ([], True),
+        ({"status": "error"}, True),
         ("Search returned no results", True),
         ("An article explaining HTTP error 429 handling patterns.", False),
         ('<Document href="https://example.com">Evidence</Document>', False),
@@ -52,6 +55,77 @@ from aiq_agent.agents.deep_researcher.tools.source_tool_batching import source_t
 )
 def test_source_tool_result_failure_classifier_is_conservative(result: object, expected: bool):
     assert source_tool_result_failed(result) is expected
+
+
+@pytest.mark.asyncio
+async def test_batch_circuit_stops_queued_provider_calls_after_first_failure():
+    calls: list[str] = []
+
+    @tool
+    async def search_tool(query: str) -> str:
+        """Search a source."""
+        calls.append(query)
+        return "Error: provider unavailable"
+
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=1,
+        max_batch_size=2,
+    )[0]
+    token = activate_source_tool_budget(2, max_consecutive_failures=1)
+    try:
+        with pytest.raises(SourceToolCircuitOpen, match="opened after 1 consecutive"):
+            await wrapped.ainvoke({"queries": ["first", "second"]})
+        assert calls == ["first"]
+    finally:
+        reset_source_tool_budget(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("batchable", [True, False])
+async def test_provider_exception_counts_toward_source_circuit(batchable: bool):
+    calls = 0
+
+    if batchable:
+
+        @tool
+        async def search_tool(query: str) -> str:
+            """Search a source."""
+            nonlocal calls
+            calls += 1
+            raise TimeoutError("provider timed out")
+
+        invocation = {"queries": "query"}
+    else:
+
+        @tool
+        async def search_tool(query: str, limit: int) -> str:
+            """Search a source."""
+            nonlocal calls
+            calls += 1
+            raise TimeoutError("provider timed out")
+
+        invocation = {"query": "query", "limit": 1}
+
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=1,
+        max_batch_size=2,
+    )[0]
+    token = activate_source_tool_budget(2, max_consecutive_failures=2)
+    try:
+        if batchable:
+            assert "provider timed out" in await wrapped.ainvoke(invocation)
+        else:
+            with pytest.raises(TimeoutError, match="provider timed out"):
+                await wrapped.ainvoke(invocation)
+        with pytest.raises(SourceToolCircuitOpen, match="opened after 2 consecutive"):
+            await wrapped.ainvoke(invocation)
+        assert calls == 2
+    finally:
+        reset_source_tool_budget(token)
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
@@ -29,6 +29,7 @@ from langchain_core.tools import tool
 
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolBudgetExceeded
+from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolCallBudget
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolCircuitOpen
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolConcurrencyLimiter
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import activate_source_tool_budget
@@ -75,11 +76,89 @@ async def test_batch_circuit_stops_queued_provider_calls_after_first_failure():
     )[0]
     token = activate_source_tool_budget(2, max_consecutive_failures=1)
     try:
-        with pytest.raises(SourceToolCircuitOpen, match="opened after 1 consecutive"):
-            await wrapped.ainvoke({"queries": ["first", "second"]})
+        output = await wrapped.ainvoke({"queries": ["first", "second"]})
+        assert output == "ERROR: Source batch returned no citable results."
         assert calls == ["first"]
+        with pytest.raises(SourceToolCircuitOpen, match="circuit is open after 1 consecutive"):
+            await wrapped.ainvoke({"queries": "third"})
     finally:
         reset_source_tool_budget(token)
+
+
+@pytest.mark.asyncio
+async def test_late_success_cannot_reset_open_circuit_failure_count():
+    budget = SourceToolCallBudget(max_calls=2, max_consecutive_failures=1)
+    success_in_flight = asyncio.Event()
+    release_success = asyncio.Event()
+
+    async def finish_success() -> None:
+        success_in_flight.set()
+        await release_success.wait()
+        await budget.record_result("valid evidence")
+
+    success_task = asyncio.create_task(finish_success())
+    await success_in_flight.wait()
+    with pytest.raises(SourceToolCircuitOpen, match="opened after 1 consecutive"):
+        await budget.record_result("Error: provider unavailable")
+    release_success.set()
+    with pytest.raises(SourceToolCircuitOpen, match="is open after 1 consecutive"):
+        await success_task
+
+    assert budget.circuit_open is True
+    assert budget.consecutive_failures == 1
+    with pytest.raises(SourceToolCircuitOpen, match="is open after 1 consecutive"):
+        await budget.consume()
+
+
+@pytest.mark.asyncio
+async def test_batch_preserves_completed_success_when_sibling_opens_circuit():
+    calls: list[str] = []
+
+    @tool
+    async def search_tool(query: str) -> str:
+        """Search a source."""
+        calls.append(query)
+        if query == "bad":
+            return "Error: provider unavailable"
+        return "Evidence at https://example.test/good"
+
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=1,
+        max_batch_size=2,
+    )[0]
+    token = activate_source_tool_budget(2, max_consecutive_failures=1)
+    try:
+        output = await wrapped.ainvoke({"queries": ["good", "bad"]})
+
+        assert calls == ["good", "bad"]
+        assert "## Query: good" in output
+        assert "https://example.test/good" in output
+        assert "## Query: bad" not in output
+        assert "provider unavailable" not in output
+    finally:
+        reset_source_tool_budget(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failed_result", [{}, [], {"status": "error"}])
+async def test_batch_filters_structured_failures_from_citable_output(failed_result: object):
+    @tool
+    async def search_tool(query: str) -> object:
+        """Search a source."""
+        return failed_result
+
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=1,
+        max_batch_size=1,
+    )[0]
+
+    output = await wrapped.ainvoke({"queries": "query"})
+
+    assert output == "ERROR: Source batch returned no citable results."
 
 
 @pytest.mark.asyncio
@@ -117,15 +196,18 @@ async def test_provider_exception_counts_toward_source_circuit(batchable: bool):
     token = activate_source_tool_budget(2, max_consecutive_failures=2)
     try:
         if batchable:
-            output = await wrapped.ainvoke(invocation)
-            assert "Source request failed." in output
-            assert "provider timed out" not in output
+            assert await wrapped.ainvoke(invocation) == "ERROR: Source batch returned no citable results."
         else:
             with pytest.raises(TimeoutError, match="provider timed out"):
                 await wrapped.ainvoke(invocation)
-        with pytest.raises(SourceToolCircuitOpen, match="opened after 2 consecutive"):
-            await wrapped.ainvoke(invocation)
+        if batchable:
+            assert await wrapped.ainvoke(invocation) == "ERROR: Source batch returned no citable results."
+        else:
+            with pytest.raises(SourceToolCircuitOpen, match="opened after 2 consecutive"):
+                await wrapped.ainvoke(invocation)
         assert calls == 2
+        with pytest.raises(SourceToolCircuitOpen, match="circuit is open after 2 consecutive"):
+            await wrapped.ainvoke(invocation)
     finally:
         reset_source_tool_budget(token)
 
@@ -262,8 +344,7 @@ async def test_batch_wrapper_represents_partial_failures_per_item():
     assert sorted(calls) == ["bad", "good"]
     assert "## Query: good" in output
     assert "ok good" in output
-    assert "## Query: bad" in output
-    assert "ERROR: Source request failed." in output
+    assert "## Query: bad" not in output
     assert "backend unavailable" not in output
 
 

--- a/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_source_tool_batching.py
@@ -28,6 +28,7 @@ from langchain_core.tools import InjectedToolArg
 from langchain_core.tools import tool
 
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
+from aiq_agent.agents.deep_researcher.tools import source_tool_batching
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolBudgetExceeded
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolCallBudget
 from aiq_agent.agents.deep_researcher.tools.source_tool_batching import SourceToolCircuitOpen
@@ -101,13 +102,58 @@ async def test_late_success_cannot_reset_open_circuit_failure_count():
     with pytest.raises(SourceToolCircuitOpen, match="opened after 1 consecutive"):
         await budget.record_result("Error: provider unavailable")
     release_success.set()
-    with pytest.raises(SourceToolCircuitOpen, match="is open after 1 consecutive"):
-        await success_task
+    await success_task
 
     assert budget.circuit_open is True
     assert budget.consecutive_failures == 1
     with pytest.raises(SourceToolCircuitOpen, match="is open after 1 consecutive"):
         await budget.consume()
+
+
+@pytest.mark.asyncio
+async def test_batch_retains_success_that_finishes_after_sibling_opens_circuit(monkeypatch: pytest.MonkeyPatch):
+    good_started = asyncio.Event()
+    release_good = asyncio.Event()
+    circuit_opened = asyncio.Event()
+
+    @tool
+    async def search_tool(query: str) -> str:
+        """Search a source."""
+        if query == "good":
+            good_started.set()
+            await release_good.wait()
+            return "Late evidence at https://example.test/late-good"
+        await good_started.wait()
+        return "Error: provider unavailable"
+
+    record_result = source_tool_batching._record_source_tool_result
+
+    async def record_and_signal(result: object) -> None:
+        try:
+            await record_result(result)
+        except SourceToolCircuitOpen:
+            circuit_opened.set()
+            raise
+
+    monkeypatch.setattr(source_tool_batching, "_record_source_tool_result", record_and_signal)
+    wrapped = adapt_source_tools_for_research(
+        [search_tool],
+        source_tool_names={"search_tool"},
+        max_concurrent_source_tool_calls=2,
+        max_batch_size=2,
+    )[0]
+    token = activate_source_tool_budget(2, max_consecutive_failures=1)
+    try:
+        batch_task = asyncio.create_task(wrapped.ainvoke({"queries": ["good", "bad"]}))
+        await circuit_opened.wait()
+        release_good.set()
+        output = await batch_task
+
+        assert "## Query: good" in output
+        assert "https://example.test/late-good" in output
+        assert "## Query: bad" not in output
+    finally:
+        reset_source_tool_budget(token)
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/guardrails/test_guardrails_registration.py
+++ b/tests/aiq_agent/guardrails/test_guardrails_registration.py
@@ -15,15 +15,31 @@
 
 """Tests for Guardrails middleware registration behavior."""
 
+from pathlib import Path
 from types import ModuleType
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+import yaml
 
 from aiq_agent.guardrails.deep_agent import register as deep_register
 from aiq_agent.guardrails.shallow_agent import register as shallow_register
 from aiq_agent.guardrails.workflow import register as workflow_register
+
+
+def test_default_guardrails_apply_baseline_input_policy_at_every_research_boundary():
+    """Public workflow and direct-agent routes must share the baseline input policy."""
+    config_path = Path(__file__).parents[3] / "configs" / "config_web_default_guardrails.yml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    middleware = config["middleware"]
+
+    def input_patterns(name: str) -> set[str]:
+        return set(middleware[name]["guardrails"]["rails"]["config"]["regex_detection"]["input"]["patterns"])
+
+    workflow_patterns = input_patterns("workflow_guardrails")
+    assert workflow_patterns <= input_patterns("shallow_agent_guardrails")
+    assert workflow_patterns <= input_patterns("deep_agent_guardrails")
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/guardrails/test_guardrails_registration.py
+++ b/tests/aiq_agent/guardrails/test_guardrails_registration.py
@@ -37,9 +37,17 @@ def test_default_guardrails_apply_baseline_input_policy_at_every_research_bounda
     def input_patterns(name: str) -> set[str]:
         return set(middleware[name]["guardrails"]["rails"]["config"]["regex_detection"]["input"]["patterns"])
 
-    workflow_patterns = input_patterns("workflow_guardrails")
-    assert workflow_patterns <= input_patterns("shallow_agent_guardrails")
-    assert workflow_patterns <= input_patterns("deep_agent_guardrails")
+    expected_baseline = {
+        (
+            r"(?i)\b(?:ignore|disregard|discard|override)\s+"
+            r"(?:(?:all|any|the)\s+)?(?:previous|prior|earlier)\s+instructions?\b"
+        ),
+        r"(?i)reveal\s+(the\s+)?system\s+prompt",
+        (r"(?i)\b(?:api[\s_-]*key|password)\s*" r"(?::|=|\bis\b|\bequals?\b)\s*\S+"),
+    }
+    assert expected_baseline <= input_patterns("workflow_guardrails")
+    assert expected_baseline <= input_patterns("shallow_agent_guardrails")
+    assert expected_baseline <= input_patterns("deep_agent_guardrails")
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/guardrails/test_workflow_guardrails.py
+++ b/tests/aiq_agent/guardrails/test_workflow_guardrails.py
@@ -100,6 +100,11 @@ def _rail_response(
 @pytest.mark.parametrize(
     ("raw_input", "expected_query_texts"),
     [
+        pytest.param(
+            {"input_message": "Please follow up with customer@example.com.", "data_sources": ["docs"]},
+            ["Please follow up with customer@example.com."],
+            id="dict-nat-generate-input-message",
+        ),
         pytest.param(  # Plain string input.
             "Research NAT guardrails",
             ["Research NAT guardrails"],
@@ -329,6 +334,15 @@ async def test_pre_invoke_modifies_when_rail_modifies(
     ("raw_input", "assert_rewrite"),
     [
         pytest.param(
+            {"input_message": "Please follow up with customer@example.com.", "data_sources": ["docs"]},
+            lambda value, modified: (
+                value["input_message"] == modified
+                and value["data_sources"] == ["docs"]
+                and set(value.keys()) == {"input_message", "data_sources"}
+            ),
+            id="dict-nat-generate-input-message",
+        ),
+        pytest.param(
             {"message": "Please follow up with customer@example.com.", "data_sources": ["docs"]},
             lambda value, modified: (
                 value["message"] == modified
@@ -418,6 +432,14 @@ async def test_pre_invoke_modifies_when_rail_modifies(
             ),
             id="object-message-history",
         ),
+        pytest.param(
+            SimpleNamespace(
+                input_message="Please follow up with customer@example.com.",
+                data_sources=["docs"],
+            ),
+            lambda value, modified: value.input_message == modified and value.data_sources == ["docs"],
+            id="object-nat-generate-input-message",
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -490,12 +512,25 @@ async def test_pre_invoke_modifies_multimodal_content_text_leaf_in_place(
     ]
 
 
+@pytest.mark.parametrize(
+    "raw_input",
+    [
+        pytest.param(
+            "Please follow up with customer@example.com about this issue.",
+            id="plain-workflow-input",
+        ),
+        pytest.param(
+            {"input_message": "Please follow up with customer@example.com about this issue."},
+            id="nat-generate-input-message",
+        ),
+    ],
+)
 @pytest.mark.asyncio
 async def test_pre_invoke_block_skips_function_invocation(
     guardrails: _WorkflowGuardrails,
+    raw_input: object,
 ):
     """A blocked `detect sensitive data on input` response skips the wrapped function."""
-    raw_input = "Please follow up with customer@example.com about this issue."
     blocked_output = TEST_REFUSAL
 
     # Blocking input rails set context.output, so the wrapped workflow must not run.


### PR DESCRIPTION
## Summary

- stop deep research after a bounded consecutive source-provider failure wave, while preserving successful evidence and the existing writer-only publication invariant
- give the orchestrator one bounded corrective turn to delegate to the writer before failing closed
- enforce the baseline input policies on `/generate`, shallow, deep, and async workflow shapes
- resolve the Sharp/libvips production advisory with Sharp 0.35.3 and add a production-only high-severity audit gate

Math/HTML/PDF rendering is intentionally out of scope.

## Validation

- `uv run pytest -q`: 2082 passed, 13 skipped
- focused deep-research/guardrail/job-runner suite: 723 passed, 6 skipped
- `uv run ruff check ...`: passed
- `nat validate --config_file configs/config_web_default_guardrails.yml`: passed
- UI Vitest: 1326 passed, 1 skipped
- UI ESLint: 0 errors (existing warnings only)
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities

### Default-config Inference Hub reliability

Built and ran exact revision `d4139ba1` through the shipped PostgreSQL + embedded-Dask async API path. The merged `config_web_default_llamaindex.yml` topology, prompts, hyperparameters, tools, and workflow settings were unchanged. Only provider transport was adapted for Inference Hub: the base URL plus provider-specific aliases for the same Super and Ultra model roles.

- Super shallow: 3/3 jobs succeeded; every job had balanced workflow, tool, and LLM start/end events; 0 job errors
- Ultra deep: 3/3 jobs succeeded; reports were 27.2K, 27.4K, and 33.0K characters with source sections, 107-230 inline citations, and 22-38 URLs; 0 job errors, 0 sentinels, 0 `writer_output_not_committed`
- Additional Harbor Ultra regression: 3/3 DeepResearch Bench II tasks completed with cited, writer-produced reports and no retries

The public-build model IDs cannot be used verbatim on this Inference Hub key (Super is denied and Ultra does not expose the same tool contract), so those transport-invalid attempts were excluded rather than counted as model/runtime failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep research now detects repeated source failures and stops safely before exhausting provider calls.
  * Research proceeds with available evidence when sources are exhausted, clearly disclosing evidence gaps.
  * Final reports receive an additional completion check to ensure they are properly produced.
* **Bug Fixes**
  * Workflow guardrails support additional input formats and consistently detect unsafe patterns.
  * Non-citable or failed source results are excluded from citations and evidence.
* **Security**
  * Production dependency audits now fail builds when high-severity vulnerabilities are detected.
* **Tests**
  * Expanded coverage validates research limits, guardrails, failure handling, citations, and report completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->