### PR TITLE
fix: enforce shallow citation integrity

### DIFF
--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -113,10 +113,18 @@ def _has_citation_integrity(report_text: str, valid_citations: Sequence[dict[str
     if source_heading is None:
         return False
     # Source-definition lines contain [N] labels but are not inline citations.
-    # Remove both the heading and definitions before accepting markers anywhere
-    # else, including a short answer that a provider placed after the section.
-    prose = report_text[: source_heading.start()] + report_text[source_heading.end() :]
-    prose = _REFERENCE_ENTRY_LINE_RE.sub("", prose)
+    # Remove only the contiguous definition block after the heading; matching
+    # globally would also erase valid prose that begins with an inline marker.
+    tail_lines = report_text[source_heading.end() :].splitlines(keepends=True)
+    first_definition = 0
+    while first_definition < len(tail_lines) and not tail_lines[first_definition].strip():
+        first_definition += 1
+    after_definitions = first_definition
+    while after_definitions < len(tail_lines) and _REFERENCE_ENTRY_LINE_RE.fullmatch(
+        tail_lines[after_definitions].rstrip("\r\n")
+    ):
+        after_definitions += 1
+    prose = report_text[: source_heading.start()] + "".join(tail_lines[after_definitions:])
     return any(int(number) in valid_numbers for number in _INLINE_CITATION_RE.findall(prose))
 
 

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -62,15 +62,75 @@ AGENT_DIR = Path(__file__).parent
 
 _SOURCE_SECTION_HEADING_RE = re.compile(
     r"^[^\S\n]*(?:"
-    r"#{1,6}[^\S\n]+(?:Sources|References)\b[^\n]*"
-    r"|\*\*(?:Sources|References):?\*\*[^\n]*"
-    r"|(?:Sources|References):[^\n]*"
-    r"|(?:Sources|References)"
+    r"#{1,6}[^\S\n]+(?:Sources|References):?"
+    r"|\*\*(?:Sources|References):?\*\*:?"
+    r"|(?:Sources|References):?"
     r")[^\S\n]*$",
-    re.IGNORECASE | re.MULTILINE,
+    re.IGNORECASE,
 )
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
-_REFERENCE_ENTRY_LINE_RE = re.compile(r"^[^\S\n]*(?:[-*][^\S\n]*)?\[\d+\][^\S\n]+.*$", re.MULTILINE)
+_REFERENCE_ENTRY_LINE_RE = re.compile(r"^[^\S\n]*(?:[-*][^\S\n]*)?\[\d+\][^\S\n]+.*$")
+
+
+def _source_section_spans(report_text: str) -> list[tuple[int, int]]:
+    """Locate canonical source headings with definitions, or empty trailing headings."""
+    lines = report_text.splitlines(keepends=True)
+    offsets: list[int] = []
+    offset = 0
+    for line in lines:
+        offsets.append(offset)
+        offset += len(line)
+
+    spans: list[tuple[int, int]] = []
+    line_index = 0
+    while line_index < len(lines):
+        heading = lines[line_index].rstrip("\r\n")
+        if _SOURCE_SECTION_HEADING_RE.fullmatch(heading) is None:
+            line_index += 1
+            continue
+
+        first_definition = line_index + 1
+        while first_definition < len(lines) and not lines[first_definition].strip():
+            first_definition += 1
+
+        after_definitions = first_definition
+        while after_definitions < len(lines) and _REFERENCE_ENTRY_LINE_RE.fullmatch(
+            lines[after_definitions].rstrip("\r\n")
+        ):
+            after_definitions += 1
+
+        if after_definitions > first_definition:
+            # Blank lines after a definition block are section separators, not
+            # answer content. Consume them so preserved prose keeps its spacing.
+            next_content = after_definitions
+            while next_content < len(lines) and not lines[next_content].strip():
+                next_content += 1
+            end = offsets[next_content] if next_content < len(lines) else len(report_text)
+            spans.append((offsets[line_index], end))
+            line_index = next_content
+        elif first_definition == len(lines):
+            spans.append((offsets[line_index], len(report_text)))
+            break
+        else:
+            # An exact heading followed by prose is answer content, not a
+            # reference section, and must not be removed.
+            line_index += 1
+
+    return spans
+
+
+def _remove_source_sections(report_text: str, spans: Sequence[tuple[int, int]]) -> str:
+    """Remove only recognized source-section spans, preserving surrounding prose."""
+    if not spans:
+        return report_text
+
+    pieces: list[str] = []
+    previous_end = 0
+    for start, end in spans:
+        pieces.append(report_text[previous_end:start])
+        previous_end = end
+    pieces.append(report_text[previous_end:])
+    return "".join(pieces)
 
 
 def _append_minimal_citation(report_text: str, source: SourceEntry) -> str:
@@ -79,12 +139,9 @@ def _append_minimal_citation(report_text: str, source: SourceEntry) -> str:
     if not citation_target:
         return report_text
 
-    content = report_text.rstrip()
-    # Replace any existing source section.  This also handles a model that
-    # emitted a valid source definition but forgot the required inline marker.
-    source_heading = _SOURCE_SECTION_HEADING_RE.search(content)
-    if source_heading is not None:
-        content = content[: source_heading.start()].rstrip()
+    # Replace only canonical source sections. Similar-looking answer headings
+    # and prose (for example, "Sources of renewable energy") are content.
+    content = _remove_source_sections(report_text, _source_section_spans(report_text)).rstrip()
     if content.endswith((".", "!", "?")):
         content = f"{content[:-1]} [1]{content[-1]}"
     else:
@@ -109,22 +166,12 @@ def _has_citation_integrity(report_text: str, valid_citations: Sequence[dict[str
     if not valid_numbers:
         return False
 
-    source_heading = _SOURCE_SECTION_HEADING_RE.search(report_text)
-    if source_heading is None:
+    source_sections = _source_section_spans(report_text)
+    if not source_sections:
         return False
-    # Source-definition lines contain [N] labels but are not inline citations.
-    # Remove only the contiguous definition block after the heading; matching
-    # globally would also erase valid prose that begins with an inline marker.
-    tail_lines = report_text[source_heading.end() :].splitlines(keepends=True)
-    first_definition = 0
-    while first_definition < len(tail_lines) and not tail_lines[first_definition].strip():
-        first_definition += 1
-    after_definitions = first_definition
-    while after_definitions < len(tail_lines) and _REFERENCE_ENTRY_LINE_RE.fullmatch(
-        tail_lines[after_definitions].rstrip("\r\n")
-    ):
-        after_definitions += 1
-    prose = report_text[: source_heading.start()] + "".join(tail_lines[after_definitions:])
+    # Definition labels are not inline citations. Remove every recognized
+    # source block so a later duplicate block cannot satisfy the invariant.
+    prose = _remove_source_sections(report_text, source_sections)
     return any(int(number) in valid_numbers for number in _INLINE_CITATION_RE.findall(prose))
 
 
@@ -330,6 +377,7 @@ class ShallowResearcherAgent:
             processed_history = list(messages)
 
             try:
+                draft_config = {"tags": [SUPPRESS_OUTPUT_ARTIFACT_TAG]}
                 if iterations >= self.max_tool_iterations:
                     logger.warning("Max iterations (%d) reached. Forcing synthesis.", iterations)
 
@@ -343,14 +391,13 @@ class ShallowResearcherAgent:
                     )
 
                     full_messages = [system_message] + processed_history + [synthesis_anchor]
-                    response = await self._get_llm().ainvoke(full_messages)
+                    response = await self._get_llm().ainvoke(full_messages, config=draft_config)
                     return {"messages": [response], "tool_iterations": iterations}
 
                 llm = self._get_llm()
                 llm_with_tools = llm.bind_tools(self.tools) if self.tools else llm
                 full_messages = [system_message] + processed_history
-                pre_evidence_config = {"tags": [SUPPRESS_OUTPUT_ARTIFACT_TAG]} if iterations == 0 else None
-                response = await llm_with_tools.ainvoke(full_messages, config=pre_evidence_config)
+                response = await llm_with_tools.ainvoke(full_messages, config=draft_config)
 
                 if self.tools and iterations == 0 and not getattr(response, "tool_calls", None):
                     logger.warning("Shallow researcher returned an answer before collecting evidence; retrying once")
@@ -363,7 +410,7 @@ class ShallowResearcherAgent:
                     retry_llm = llm.bind_tools(self.tools, parallel_tool_calls=False)
                     response = await retry_llm.ainvoke(
                         full_messages + [response, tool_required],
-                        config=pre_evidence_config,
+                        config=draft_config,
                     )
                     retry_tool_calls = getattr(response, "tool_calls", None) or []
                     if len(retry_tool_calls) != 1 or retry_tool_calls[0].get("name") not in source_tool_names:

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -60,10 +61,16 @@ logger = logging.getLogger(__name__)
 AGENT_DIR = Path(__file__).parent
 
 _SOURCE_SECTION_HEADING_RE = re.compile(
-    r"^[^\S\n]*(?:#{1,3}[^\S\n]+(?:Sources|References)|\*\*(?:Sources|References):?\*\*)[^\S\n]*$",
+    r"^[^\S\n]*(?:"
+    r"#{1,6}[^\S\n]+(?:Sources|References)\b[^\n]*"
+    r"|\*\*(?:Sources|References):?\*\*[^\n]*"
+    r"|(?:Sources|References):[^\n]*"
+    r"|(?:Sources|References)"
+    r")[^\S\n]*$",
     re.IGNORECASE | re.MULTILINE,
 )
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
+_REFERENCE_ENTRY_LINE_RE = re.compile(r"^[^\S\n]*(?:[-*][^\S\n]*)?\[\d+\][^\S\n]+.*$", re.MULTILINE)
 
 
 def _append_minimal_citation(report_text: str, source: SourceEntry) -> str:
@@ -105,8 +112,12 @@ def _has_citation_integrity(report_text: str, valid_citations: Sequence[dict[str
     source_heading = _SOURCE_SECTION_HEADING_RE.search(report_text)
     if source_heading is None:
         return False
-    body = report_text[: source_heading.start()]
-    return any(int(number) in valid_numbers for number in _INLINE_CITATION_RE.findall(body))
+    # Source-definition lines contain [N] labels but are not inline citations.
+    # Remove both the heading and definitions before accepting markers anywhere
+    # else, including a short answer that a provider placed after the section.
+    prose = report_text[: source_heading.start()] + report_text[source_heading.end() :]
+    prose = _REFERENCE_ENTRY_LINE_RE.sub("", prose)
+    return any(int(number) in valid_numbers for number in _INLINE_CITATION_RE.findall(prose))
 
 
 def _format_citation_repair_sources(sources: Sequence[SourceEntry]) -> str:
@@ -153,6 +164,7 @@ class ShallowResearcherAgent:
         system_prompt: str | None = None,
         max_llm_turns: int = 10,
         max_tool_iterations: int = 5,
+        citation_repair_timeout: float = 60.0,
         callbacks: list[Any] | None = None,
     ) -> None:
         """
@@ -166,12 +178,15 @@ class ShallowResearcherAgent:
             max_llm_turns: Maximum LLM interaction turns (default 10).
             max_tool_iterations: Maximum tool-calling iterations before forcing
                                 synthesis (default 5).
+            citation_repair_timeout: Maximum seconds for the one-shot citation
+                                     repair call (default 60).
             callbacks: Optional list of LangGraph callbacks.
         """
         self.llm_provider = llm_provider
         self.tools = list(tools)
         self.max_llm_turns = max_llm_turns
         self.max_tool_iterations = max_tool_iterations
+        self.citation_repair_timeout = citation_repair_timeout
         self.callbacks = callbacks or []
 
         # Load prompts
@@ -245,9 +260,12 @@ class ShallowResearcherAgent:
             repair_config["callbacks"] = self.callbacks
 
         try:
-            response = await self._get_llm().ainvoke(
-                [repair_system, *messages, repair_request],
-                config=repair_config,
+            response = await asyncio.wait_for(
+                self._get_llm().ainvoke(
+                    [repair_system, *messages, repair_request],
+                    config=repair_config,
+                ),
+                timeout=self.citation_repair_timeout,
             )
         except Exception as ex:
             logger.warning(

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -39,6 +39,7 @@ from aiq_agent.common import get_source_id_for_tool
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
 from aiq_agent.common.callbacks import SUPPRESS_OUTPUT_ARTIFACT_TAG
+from aiq_agent.common.citation_verification import CitationIntegrityError
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
 from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import SourceRegistry
@@ -58,6 +59,12 @@ logger = logging.getLogger(__name__)
 # Path to this agent's directory (for loading prompts)
 AGENT_DIR = Path(__file__).parent
 
+_SOURCE_SECTION_HEADING_RE = re.compile(
+    r"^[^\S\n]*(?:#{1,3}[^\S\n]+(?:Sources|References)|\*\*(?:Sources|References):?\*\*)[^\S\n]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
+
 
 def _append_minimal_citation(report_text: str, source: SourceEntry) -> str:
     """Append one verified citation when the model omitted references."""
@@ -65,23 +72,12 @@ def _append_minimal_citation(report_text: str, source: SourceEntry) -> str:
     if not citation_target:
         return report_text
 
-    # verify_citations may strip every citation line under a **References:**
-    # (or ## References / ## Sources) header and leave the empty header
-    # behind. Drop that trailing header before we append our own so the final
-    # output has exactly one references section.
     content = report_text.rstrip()
-    content = re.sub(
-        r"\n{1,2}\*\*References:?\*\*\s*$",
-        "",
-        content,
-        flags=re.IGNORECASE,
-    ).rstrip()
-    content = re.sub(
-        r"\n{1,2}#{2,3}\s+(?:References|Sources)\s*$",
-        "",
-        content,
-        flags=re.IGNORECASE,
-    ).rstrip()
+    # Replace any existing source section.  This also handles a model that
+    # emitted a valid source definition but forgot the required inline marker.
+    source_heading = _SOURCE_SECTION_HEADING_RE.search(content)
+    if source_heading is not None:
+        content = content[: source_heading.start()].rstrip()
     if content.endswith((".", "!", "?")):
         content = f"{content[:-1]} [1]{content[-1]}"
     else:
@@ -94,6 +90,34 @@ def _append_minimal_citation(report_text: str, source: SourceEntry) -> str:
         reference = f"- [1] {citation_target}"
 
     return f"{content}\n\n**References:**\n{reference}"
+
+
+def _has_citation_integrity(report_text: str, valid_citations: Sequence[dict[str, Any]]) -> bool:
+    """Return whether a verified report has both a source and an inline marker."""
+    valid_numbers = {
+        int(number)
+        for citation in valid_citations
+        if (number := citation.get("number")) is not None and str(number).isdigit()
+    }
+    if not valid_numbers:
+        return False
+
+    source_heading = _SOURCE_SECTION_HEADING_RE.search(report_text)
+    if source_heading is None:
+        return False
+    body = report_text[: source_heading.start()]
+    return any(int(number) in valid_numbers for number in _INLINE_CITATION_RE.findall(body))
+
+
+def _format_citation_repair_sources(sources: Sequence[SourceEntry]) -> str:
+    """Render numbered source lines that a repair pass can copy verbatim."""
+    lines: list[str] = []
+    for number, source in enumerate(sources, 1):
+        if source.url:
+            lines.append(f"- [{number}] Source {number} - {source.url}")
+        elif source.citation_key:
+            lines.append(f"- [{number}] {source.citation_key}")
+    return "\n".join(lines)
 
 
 class ShallowResearcherAgent:
@@ -187,6 +211,56 @@ class ShallowResearcherAgent:
     def _get_llm(self) -> BaseChatModel:
         """Get the LLM for shallow research."""
         return self.llm_provider.get(LLMRole.RESEARCHER)
+
+    async def _repair_missing_citations(
+        self,
+        messages: Sequence[Any],
+        sources: Sequence[SourceEntry],
+    ) -> str:
+        """Run one bounded, tool-free repair against captured source identities."""
+        source_catalog = _format_citation_repair_sources(sources)
+        if not source_catalog:
+            raise CitationIntegrityError()
+
+        repair_system = SystemMessage(
+            content=(
+                "You are a deterministic citation-repair editor. Do not answer the original question again from "
+                "memory and do not call tools. Rewrite only the immediately preceding draft. Keep only claims "
+                "supported by prior tool results. Your response is invalid unless it contains at least one inline "
+                "[N] marker and a final **References:** section copied from the allowed reference lines."
+            )
+        )
+        repair_request = HumanMessage(
+            content=(
+                "The immediately preceding draft failed the citation contract. Rewrite it once using only claims "
+                "supported by the prior tool results. Preserve the answer's meaning, remove unsupported claims, "
+                "and do not call tools. Add an inline [N] marker after each externally verified claim and finish "
+                "with a `**References:**` section. Copy the corresponding allowed reference lines verbatim; never "
+                "invent or reconstruct a URL. Return only the repaired report.\n\n"
+                f"Allowed reference lines:\n{source_catalog}"
+            )
+        )
+        repair_config: dict[str, Any] = {"tags": [SUPPRESS_OUTPUT_ARTIFACT_TAG]}
+        if self.callbacks:
+            repair_config["callbacks"] = self.callbacks
+
+        try:
+            response = await self._get_llm().ainvoke(
+                [repair_system, *messages, repair_request],
+                config=repair_config,
+            )
+        except Exception as ex:
+            logger.warning(
+                "Shallow citation repair failed (error_type=%s detail_%s)",
+                type(ex).__name__,
+                log_content_metadata(ex),
+            )
+            raise CitationIntegrityError() from ex
+
+        repaired_content = getattr(response, "content", None)
+        if not isinstance(repaired_content, str) or not repaired_content.strip():
+            raise CitationIntegrityError()
+        return repaired_content
 
     def _build_graph(self) -> CompiledStateGraph:
         """Build the LangGraph StateGraph."""
@@ -422,12 +496,40 @@ class ShallowResearcherAgent:
                     )
                     content = verification.verified_report
                     sources = registry.all_sources()
-                    if not verification.valid_citations and len(sources) == 1:
+                    citation_integrity = _has_citation_integrity(content, verification.valid_citations)
+                    if not citation_integrity and len(sources) == 1:
                         content = _append_minimal_citation(content, sources[0])
+                    elif not citation_integrity:
+                        logger.info(
+                            "Shallow report is missing citation integrity; attempting one bounded repair "
+                            "(registered_sources=%d)",
+                            len(sources),
+                        )
+                        content = await self._repair_missing_citations(validated_result["messages"], sources)
+                        repair_verification = verify_citations(content, registry, reference_sources=sources)
+                        content = repair_verification.verified_report
+                        if not _has_citation_integrity(content, repair_verification.valid_citations):
+                            logger.warning(
+                                "Shallow citation repair did not restore integrity "
+                                "(registered_sources=%d verified_sources=%d)",
+                                len(sources),
+                                len(repair_verification.valid_citations),
+                            )
                 # Step 2: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
                 sanitization = sanitize_report(content)
                 content = sanitization.sanitized_report
                 final_verification = verify_citations(content, registry)
+                if not _has_citation_integrity(
+                    final_verification.verified_report,
+                    final_verification.valid_citations,
+                ):
+                    logger.warning(
+                        "Shallow report failed final citation integrity check "
+                        "(registered_sources=%d verified_sources=%d)",
+                        len(registry.all_sources()),
+                        len(final_verification.valid_citations),
+                    )
+                    raise CitationIntegrityError()
                 content = final_verification.verified_report
                 final_cited_urls = list(
                     dict.fromkeys(

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -69,7 +69,31 @@ _SOURCE_SECTION_HEADING_RE = re.compile(
     re.IGNORECASE,
 )
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
-_REFERENCE_ENTRY_LINE_RE = re.compile(r"^[^\S\n]*(?:[-*][^\S\n]*)?\[\d+\][^\S\n]+.*$")
+_REFERENCE_ENTRY_LINE_RE = re.compile(r"^[^\S\n]*(?P<bullet>[-*][^\S\n]*)?\[(?P<number>\d+)\][^\S\n]+(?P<target>.+)$")
+_REFERENCE_TARGET_RE = re.compile(
+    r"(?:https?://\S+|[^\s,]+\.\w{2,5}(?:,[^\n]+)?|[A-Za-z0-9]+(?:_+[A-Za-z0-9]+)+)$",
+    re.IGNORECASE,
+)
+
+
+def _reference_entry_number(line: str, previous_number: int | None) -> int | None:
+    """Return a reference number only for an unambiguous definition line."""
+    match = _REFERENCE_ENTRY_LINE_RE.fullmatch(line)
+    if match is None:
+        return None
+
+    number = int(match.group("number"))
+    if previous_number is not None and number <= previous_number:
+        # Reference definitions are unique and ordered. A repeated/reset
+        # marker begins answer prose, even when it immediately follows them.
+        return None
+
+    target = match.group("target").strip()
+    if match.group("bullet") is None and _REFERENCE_TARGET_RE.search(target) is None:
+        # An unbulleted marker-first sentence is answer text. Verified
+        # unbulleted definitions carry a URL, file/page key, or tool key.
+        return None
+    return number
 
 
 def _source_section_spans(report_text: str) -> list[tuple[int, int]]:
@@ -94,9 +118,12 @@ def _source_section_spans(report_text: str) -> list[tuple[int, int]]:
             first_definition += 1
 
         after_definitions = first_definition
-        while after_definitions < len(lines) and _REFERENCE_ENTRY_LINE_RE.fullmatch(
-            lines[after_definitions].rstrip("\r\n")
-        ):
+        previous_number: int | None = None
+        while after_definitions < len(lines):
+            number = _reference_entry_number(lines[after_definitions].rstrip("\r\n"), previous_number)
+            if number is None:
+                break
+            previous_number = number
             after_definitions += 1
 
         if after_definitions > first_definition:

--- a/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
@@ -1,19 +1,46 @@
-You are a rapid research agent. Give a direct, current, evidence-backed answer using only the available tools.
+You are a Shallow Research Agent. Your role is to provide rapid, citation-backed answers using available tools.
 
-## Required behavior
+## MANDATORY: Research Before Answering
+When at least one research tool is available, your first response MUST be a tool call. Never answer directly from memory.
 
-1. When a research tool is available, your first response MUST be a tool call. Never answer from memory first.
-2. Rewrite the question as a precise search query. Include the relevant entity, claim, date, and scope.
-3. Verify the question's premise before accepting it. If an assumed event, relationship, count, title, or entity is
-   false or unsupported, say so directly; never invent the requested detail.
-4. Use the highest-priority relevant source: user documents for questions about provided files, academic search for
-   research claims, and web search for current or general facts.
-5. Make at most two calls per tool. Search again only when the first result is empty, irrelevant, or conflicting.
-6. Lead with the answer. Prefer one to three concise sentences unless the question requires more detail.
-7. Cite every externally verified claim inline as [1], [2], and finish with `**References:**`. Each reference must be
-   `- [N] Title - URL`, using an exact URL returned by a tool. Never invent or reconstruct a URL.
-8. If useful evidence was returned, do not claim that no source was found. If two targeted searches return no useful
-   evidence, state exactly what could not be verified.
+- This rule applies even when the question looks simple, familiar, or based on a false premise. Search to verify the answer or premise.
+- Do not produce a final answer until at least one research tool call has completed.
+- If the first search is empty or irrelevant, rewrite the query and search once more before synthesizing.
+- After receiving useful results, answer promptly. Do not keep searching when one call provides enough evidence.
+
+## CRITICAL: Source Hierarchy
+Prioritize sources based on the query intent:
+
+1. **User Documents (Highest Priority)**: If a knowledge_search or document tool is available, use it first for "my files," "the uploaded doc," or personal/provided data.
+2. **Academic Research**: If a paper search tool is available, use for scientific or technical validation.
+3. **Web Search**: If a web search tool is available, use it for general facts, news, or when other sources are silent.
+
+## Query Rewriting (before calling search tools)
+Before calling any search tool, rewrite the user's question into a **search-friendly query** that includes **all context the user implied**. Add whatever is needed for the index to return relevant results — do not pass the raw user message if it relies on implicit context.
+
+- **Add missing context**: Time (current date/year from the Context section below), scope, topic, or other details the user assumed but the search index does not have.
+- **Examples**: Add current year for "upcoming" or "next" questions; expand vague shorthand with the obvious topic or scope.
+
+Pass the **rewritten query** to the search tool. This greatly improves result relevance.
+
+## Research Rules
+- **Only use tools listed** in the Available Tools section below. Do not assume access to tools not listed. If no web search tool is listed, you have NO web access.
+- **Loop Prevention**: Max 2 calls per tool. If results are empty, change your search string once or move to synthesis.
+
+## Citation Rules
+Cite sources inline with [1], [2], etc. Include a `**References:**` section at the end.
+- **Format**: `- [N] Title - URL` or `- [N] filename.pdf, p.X` for internal documents
+- Use only URLs that appeared in tool results. Do not add URLs from memory.
+- If you use a tool result to answer, include at least one inline citation and a `**References:**` section.
+- For tool results without URLs or document citation keys, cite the exact tool name from the tool call: `- [1] mcp_time__get_current_time`.
+- Before returning an answer based on tool results, verify that it contains both an inline [N] marker and a non-empty `**References:**` section.
+- Citations are automatically verified — focus on answering the question, not on perfecting references.
+
+**Example**:
+"The uploaded report shows a 5% margin [1].
+
+**References:**
+- [1] Q4_Review.pdf, p. 2 (Internal)"
 
 {#- === KV CACHE BOUNDARY — dynamic content below === -#}
 
@@ -32,10 +59,11 @@ User: {{ user_info.name or "Unknown" }} ({{ user_info.email or "Unknown" }})
 {% endif %}
 
 {% if available_documents %}
-## Uploaded Documents
+## Uploaded Documents (IMPORTANT)
+The user has uploaded the following documents to the knowledge base:
 {% for doc in available_documents %}
 - **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
 {% endfor %}
 
-For questions about these documents, use `knowledge_search`; web search cannot access them.
+**CRITICAL**: When the user asks to summarize, describe, explain, or query their uploaded documents, you MUST use the **knowledge_search** tool — NOT web search. Only **knowledge_search** has access to these uploaded documents.
 {% endif %}

--- a/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
@@ -1,45 +1,19 @@
-You are a Shallow Research Agent. Your role is to provide rapid, citation-backed answers using available tools.
+You are a rapid research agent. Give a direct, current, evidence-backed answer using only the available tools.
 
-## MANDATORY: Research Before Answering
-When at least one research tool is available, your first response MUST be a tool call. Never answer directly from memory.
+## Required behavior
 
-- This rule applies even when the question looks simple, familiar, or based on a false premise. Search to verify the answer or premise.
-- Do not produce a final answer until at least one research tool call has completed.
-- If the first search is empty or irrelevant, rewrite the query and search once more before synthesizing.
-- After receiving useful results, answer promptly. Do not keep searching when one call provides enough evidence.
-
-## CRITICAL: Source Hierarchy
-Prioritize sources based on the query intent:
-
-1. **User Documents (Highest Priority)**: If a knowledge_search or document tool is available, use it first for "my files," "the uploaded doc," or personal/provided data.
-2. **Academic Research**: If a paper search tool is available, use for scientific or technical validation.
-3. **Web Search**: If a web search tool is available, use it for general facts, news, or when other sources are silent.
-
-## Query Rewriting (before calling search tools)
-Before calling any search tool, rewrite the user's question into a **search-friendly query** that includes **all context the user implied**. Add whatever is needed for the index to return relevant results — do not pass the raw user message if it relies on implicit context.
-
-- **Add missing context**: Time (current date/year from the Context section below), scope, topic, or other details the user assumed but the search index does not have.
-- **Examples**: Add current year for "upcoming" or "next" questions; expand vague shorthand with the obvious topic or scope.
-
-Pass the **rewritten query** to the search tool. This greatly improves result relevance.
-
-## Research Rules
-- **Only use tools listed** in the Available Tools section below. Do not assume access to tools not listed. If no web search tool is listed, you have NO web access.
-- **Loop Prevention**: Max 2 calls per tool. If results are empty, change your search string once or move to synthesis.
-
-## Citation Rules
-Cite sources inline with [1], [2], etc. Include a `**References:**` section at the end.
-- **Format**: `- [N] Title - URL` or `- [N] filename.pdf, p.X` for internal documents
-- Use only URLs that appeared in tool results. Do not add URLs from memory.
-- If you use a tool result to answer, include at least one inline citation and a `**References:**` section.
-- For tool results without URLs or document citation keys, cite the exact tool name from the tool call: `- [1] mcp_time__get_current_time`.
-- Citations are automatically verified — focus on answering the question, not on perfecting references.
-
-**Example**:
-"The uploaded report shows a 5% margin [1].
-
-**References:**
-- [1] Q4_Review.pdf, p. 2 (Internal)"
+1. When a research tool is available, your first response MUST be a tool call. Never answer from memory first.
+2. Rewrite the question as a precise search query. Include the relevant entity, claim, date, and scope.
+3. Verify the question's premise before accepting it. If an assumed event, relationship, count, title, or entity is
+   false or unsupported, say so directly; never invent the requested detail.
+4. Use the highest-priority relevant source: user documents for questions about provided files, academic search for
+   research claims, and web search for current or general facts.
+5. Make at most two calls per tool. Search again only when the first result is empty, irrelevant, or conflicting.
+6. Lead with the answer. Prefer one to three concise sentences unless the question requires more detail.
+7. Cite every externally verified claim inline as [1], [2], and finish with `**References:**`. Each reference must be
+   `- [N] Title - URL`, using an exact URL returned by a tool. Never invent or reconstruct a URL.
+8. If useful evidence was returned, do not claim that no source was found. If two targeted searches return no useful
+   evidence, state exactly what could not be verified.
 
 {#- === KV CACHE BOUNDARY — dynamic content below === -#}
 
@@ -58,11 +32,10 @@ User: {{ user_info.name or "Unknown" }} ({{ user_info.email or "Unknown" }})
 {% endif %}
 
 {% if available_documents %}
-## Uploaded Documents (IMPORTANT)
-The user has uploaded the following documents to the knowledge base:
+## Uploaded Documents
 {% for doc in available_documents %}
 - **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
 {% endfor %}
 
-**CRITICAL**: When the user asks to summarize, describe, explain, or query their uploaded documents, you MUST use the **knowledge_search** tool — NOT web search. Only **knowledge_search** has access to these uploaded documents.
+For questions about these documents, use `knowledge_search`; web search cannot access them.
 {% endif %}

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -555,12 +555,17 @@ def weather_observation_tool(location: str) -> str:
 def knowledge_search(query: str) -> str:
     """Search uploaded documents and return file citation metadata."""
     return (
-        "Found 1 relevant document(s):\n\n"
+        "Found 2 relevant document(s):\n\n"
         "--- Result 1 ---\n"
         "Source: report.pdf\n"
         "Page: 15\n"
         "Citation: report.pdf, p.15\n\n"
-        f"Relevant content for {query}."
+        f"Relevant content for {query}.\n\n"
+        "--- Result 2 ---\n"
+        "Source: appendix.pdf\n"
+        "Page: 4\n"
+        "Citation: appendix.pdf, p.4\n\n"
+        "Supporting appendix content."
     )
 
 
@@ -697,7 +702,13 @@ class TestShallowResearcherSourceRegistryGating:
             tool_calls=[{"name": "knowledge_search", "args": {"query": "revenue summary"}, "id": "1"}],
         )
         uncited_summary = AIMessage(content="The uploaded report says revenue increased.")
-        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, uncited_summary])
+        repaired_summary = AIMessage(
+            content=("The uploaded report says revenue increased [1].\n\n**References:**\n- [1] report.pdf, p.15")
+        )
+        bound_llm = MagicMock()
+        bound_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, uncited_summary])
+        mock_llm.bind_tools = MagicMock(return_value=bound_llm)
+        mock_llm.ainvoke = AsyncMock(return_value=repaired_summary)
         callback = MagicMock()
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
@@ -710,11 +721,14 @@ class TestShallowResearcherSourceRegistryGating:
         )
 
         sources = agent.source_registry.all_sources()
-        assert len(sources) == 1
+        assert len(sources) == 2
         assert sources[0].citation_key == "report.pdf, p.15"
         assert sources[0].source_type == "knowledge_layer"
+        assert sources[1].citation_key == "appendix.pdf, p.4"
         assert "The uploaded report says revenue increased [1]." in result.messages[-1].content
         assert "[1] report.pdf, p.15" in result.messages[-1].content
+        assert bound_llm.ainvoke.await_count == 2
+        mock_llm.ainvoke.assert_awaited_once()
         callback.emit_final_report.assert_called_once_with(result.messages[-1].content, cited_urls=[])
 
     @pytest.mark.asyncio
@@ -1351,3 +1365,8 @@ class TestCitationIntegrity:
         report = "Answer without a marker.\n\nSources:\n- [1] Source - https://example.com/source"
 
         assert not _has_citation_integrity(report, [{"number": 1, "url": "https://example.com/source"}])
+
+    def test_preserves_answer_line_that_begins_with_an_inline_marker(self):
+        report = "[1] CUDA is a parallel computing platform.\n\nSources:\n- [1] CUDA - https://example.com/cuda"
+
+        assert _has_citation_integrity(report, [{"number": 1, "url": "https://example.com/cuda"}])

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -15,6 +15,8 @@
 
 """Tests for the ShallowResearcherAgent."""
 
+import asyncio
+import re
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import call
@@ -28,6 +30,7 @@ from langchain_core.tools import tool
 
 from aiq_agent.agents.shallow_researcher.agent import ShallowResearcherAgent
 from aiq_agent.agents.shallow_researcher.agent import _append_minimal_citation
+from aiq_agent.agents.shallow_researcher.agent import _has_citation_integrity
 from aiq_agent.agents.shallow_researcher.models import ShallowResearchAgentState
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
@@ -105,6 +108,7 @@ class TestShallowResearcherAgent:
         assert len(agent.tools) == 1
         assert agent.max_llm_turns == 10
         assert agent.max_tool_iterations == 5
+        assert agent.citation_repair_timeout == 60.0
         assert agent.callbacks == []
         assert agent.system_prompt is not None
 
@@ -293,16 +297,36 @@ class TestShallowResearcherAgent:
             )
             assert "research" in agent.system_prompt.lower()
 
-    def test_default_prompt_requires_research_and_exact_citations(self, mock_llm_provider, real_tool):
-        """Default prompt preserves the tested compact research and citation contract."""
+    def test_default_prompt_has_structural_citation_contract(self, mock_llm_provider, real_tool):
+        """Default prompt preserves the shared research and citation contract."""
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[real_tool],
         )
 
-        assert "your first response MUST be a tool call" in agent.system_prompt
-        assert "Cite every externally verified claim inline" in agent.system_prompt
-        assert "using an exact URL returned by a tool" in agent.system_prompt
+        assert re.search(r"\[\d+\]", agent.system_prompt)
+        assert "**References:**" in agent.system_prompt
+        assert "- [1] mcp_time__get_current_time" in agent.system_prompt
+
+    @pytest.mark.asyncio
+    async def test_citation_repair_timeout_fails_closed(self, mock_llm_provider, mock_llm):
+        """A stalled provider cannot extend a completed shallow run indefinitely."""
+
+        async def stalled_repair(*_args, **_kwargs):
+            await asyncio.sleep(1)
+
+        mock_llm.ainvoke = AsyncMock(side_effect=stalled_repair)
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[],
+            citation_repair_timeout=0.001,
+        )
+
+        with pytest.raises(CitationIntegrityError, match="citation_integrity_lost"):
+            await agent._repair_missing_citations(
+                [HumanMessage(content="Draft")],
+                [SourceEntry(url="https://example.com/source")],
+            )
 
     @pytest.mark.asyncio
     async def test_initial_answer_without_tool_call_is_retried(self, mock_llm_provider, mock_llm, real_tool):
@@ -708,7 +732,10 @@ class TestShallowResearcherSourceRegistryGating:
         repaired_response = AIMessage(
             content="CUDA is a parallel computing platform [2]. The current time came from the time tool [1]."
         )
-        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, final_response, repaired_response])
+        bound_llm = MagicMock()
+        bound_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, final_response])
+        mock_llm.bind_tools = MagicMock(return_value=bound_llm)
+        mock_llm.ainvoke = AsyncMock(return_value=repaired_response)
 
         callback = MagicMock()
         agent = ShallowResearcherAgent(
@@ -730,10 +757,11 @@ class TestShallowResearcherSourceRegistryGating:
             result.messages[-1].content,
             cited_urls=["https://docs.nvidia.com/cuda/"],
         )
-        assert mock_llm.ainvoke.await_count == 3
-        repair_call = mock_llm.ainvoke.await_args_list[-1]
+        assert bound_llm.ainvoke.await_count == 2
+        mock_llm.ainvoke.assert_awaited_once()
+        assert mock_llm.bind_tools.call_count == 2
+        repair_call = mock_llm.ainvoke.await_args
         assert repair_call.kwargs["config"]["tags"] == [SUPPRESS_OUTPUT_ARTIFACT_TAG]
-        assert "do not call tools" in repair_call.args[0][-1].content
         assert isinstance(repair_call.args[0][0], SystemMessage)
 
     @pytest.mark.asyncio
@@ -1234,3 +1262,41 @@ class TestAppendMinimalCitation:
         result = _append_minimal_citation(report, self._tool_source())
 
         assert result == "Body sentence [1].\n\n**References:**\n- [1] mcp_time__get_current_time"
+
+    @pytest.mark.parametrize(
+        "heading",
+        [
+            "###### References and notes",
+            "Sources:",
+            "**References:** selected sources",
+        ],
+    )
+    def test_replaces_supported_heading_variants(self, heading):
+        report = f"Body sentence.\n\n{heading}\n[1] mcp_time__get_current_time"
+
+        result = _append_minimal_citation(report, self._tool_source())
+
+        assert heading not in result
+        assert result == "Body sentence [1].\n\n**References:**\n- [1] mcp_time__get_current_time"
+
+
+class TestCitationIntegrity:
+    """Tests for the final inline-plus-source publication invariant."""
+
+    @pytest.mark.parametrize(
+        "heading",
+        [
+            "###### References and notes",
+            "Sources:",
+            "**References:** selected sources",
+        ],
+    )
+    def test_accepts_inline_marker_outside_reference_definitions(self, heading):
+        report = f"{heading}\n- [1] Source - https://example.com/source\n\nAnswer [1]."
+
+        assert _has_citation_integrity(report, [{"number": 1, "url": "https://example.com/source"}])
+
+    def test_does_not_treat_reference_definition_as_inline_citation(self):
+        report = "Answer without a marker.\n\nSources:\n- [1] Source - https://example.com/source"
+
+        assert not _has_citation_integrity(report, [{"number": 1, "url": "https://example.com/source"}])

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -551,6 +551,19 @@ def weather_observation_tool(location: str) -> str:
     return f"Current conditions for {location}: clear, 68F"
 
 
+@tool
+def knowledge_search(query: str) -> str:
+    """Search uploaded documents and return file citation metadata."""
+    return (
+        "Found 1 relevant document(s):\n\n"
+        "--- Result 1 ---\n"
+        "Source: report.pdf\n"
+        "Page: 15\n"
+        "Citation: report.pdf, p.15\n\n"
+        f"Relevant content for {query}."
+    )
+
+
 class TestShallowResearcherSourceRegistryGating:
     """Tests that shallow source capture is gated by data_source_registry."""
 
@@ -665,6 +678,44 @@ class TestShallowResearcherSourceRegistryGating:
         assert result.messages[-1].content.rstrip() == (
             "It's currently 4:54 AM in Tokyo [1].\n\n## Sources\n- [1] mcp_time__get_current_time"
         )
+
+    @pytest.mark.asyncio
+    async def test_missing_uploaded_document_citation_is_repaired_before_publication(self, mock_llm_provider, mock_llm):
+        """Knowledge-search summaries enforce file citation keys without requiring public URLs."""
+        populate_from_config(
+            [
+                {
+                    "id": "knowledge_layer",
+                    "name": "Knowledge Layer",
+                    "description": "Search uploaded documents.",
+                    "tools": ["knowledge_search"],
+                }
+            ]
+        )
+        tool_call_response = AIMessage(
+            content="",
+            tool_calls=[{"name": "knowledge_search", "args": {"query": "revenue summary"}, "id": "1"}],
+        )
+        uncited_summary = AIMessage(content="The uploaded report says revenue increased.")
+        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, uncited_summary])
+        callback = MagicMock()
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[knowledge_search],
+            callbacks=[callback],
+        )
+
+        result = await agent.run(
+            ShallowResearchAgentState(messages=[HumanMessage(content="Summarize the uploaded revenue report.")])
+        )
+
+        sources = agent.source_registry.all_sources()
+        assert len(sources) == 1
+        assert sources[0].citation_key == "report.pdf, p.15"
+        assert sources[0].source_type == "knowledge_layer"
+        assert "The uploaded report says revenue increased [1]." in result.messages[-1].content
+        assert "[1] report.pdf, p.15" in result.messages[-1].content
+        callback.emit_final_report.assert_called_once_with(result.messages[-1].content, cited_urls=[])
 
     @pytest.mark.asyncio
     async def test_missing_url_citation_fallback_emits_authoritative_metadata(self, mock_llm_provider, mock_llm):

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -322,11 +322,12 @@ class TestShallowResearcherAgent:
             citation_repair_timeout=0.001,
         )
 
-        with pytest.raises(CitationIntegrityError, match="citation_integrity_lost"):
-            await agent._repair_missing_citations(
-                [HumanMessage(content="Draft")],
-                [SourceEntry(url="https://example.com/source")],
-            )
+        async with asyncio.timeout(0.1):
+            with pytest.raises(CitationIntegrityError, match="citation_integrity_lost"):
+                await agent._repair_missing_citations(
+                    [HumanMessage(content="Draft")],
+                    [SourceEntry(url="https://example.com/source")],
+                )
 
     @pytest.mark.asyncio
     async def test_initial_answer_without_tool_call_is_retried(self, mock_llm_provider, mock_llm, real_tool):
@@ -1371,6 +1372,14 @@ class TestAppendMinimalCitation:
         assert "Closing answer [1]." in result
         assert "Old source" not in result
 
+    def test_preserves_marker_first_answer_immediately_after_reference_block(self):
+        report = "## Sources\n[1] mcp_time__get_current_time\n[1] CUDA is a parallel computing platform."
+
+        result = _append_minimal_citation(report, self._tool_source())
+
+        assert "CUDA is a parallel computing platform" in result
+        assert result.count("mcp_time__get_current_time") == 1
+
 
 class TestCitationIntegrity:
     """Tests for the final inline-plus-source publication invariant."""
@@ -1401,3 +1410,8 @@ class TestCitationIntegrity:
         )
 
         assert not _has_citation_integrity(report, [{"number": 1, "url": "https://example.com/first"}])
+
+    def test_preserves_marker_first_answer_after_reference_definitions(self):
+        report = "## Sources\n[1] mcp_time__get_current_time\n[1] CUDA is a parallel computing platform."
+
+        assert _has_citation_integrity(report, [{"number": 1, "citation_key": "mcp_time__get_current_time"}])

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
+from langchain_core.messages import SystemMessage
 from langchain_core.tools import tool
 
 from aiq_agent.agents.shallow_researcher.agent import ShallowResearcherAgent
@@ -31,6 +32,7 @@ from aiq_agent.agents.shallow_researcher.models import ShallowResearchAgentState
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
 from aiq_agent.common.callbacks import SUPPRESS_OUTPUT_ARTIFACT_TAG
+from aiq_agent.common.citation_verification import CitationIntegrityError
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
 from aiq_agent.common.citation_verification import EmptySourceRegistryReason
 from aiq_agent.common.citation_verification import SourceEntry
@@ -66,6 +68,7 @@ class TestShallowResearcherAgent:
             patch.object(SourceRegistry, "all_sources", return_value=[SourceEntry(url="https://example.com")]),
             patch("aiq_agent.agents.shallow_researcher.agent.verify_citations") as mock_verify,
             patch("aiq_agent.agents.shallow_researcher.agent.sanitize_report") as mock_sanitize,
+            patch("aiq_agent.agents.shallow_researcher.agent._has_citation_integrity", return_value=True),
         ):
             mock_verify.side_effect = lambda content, reg: MagicMock(verified_report=content, removed_citations=[])
             mock_sanitize.side_effect = lambda content: MagicMock(sanitized_report=content)
@@ -290,16 +293,16 @@ class TestShallowResearcherAgent:
             )
             assert "research" in agent.system_prompt.lower()
 
-    def test_default_prompt_requires_tool_result_references(self, mock_llm_provider, real_tool):
-        """Default prompt tells the model to cite non-URL tool results by exact tool name."""
+    def test_default_prompt_requires_research_and_exact_citations(self, mock_llm_provider, real_tool):
+        """Default prompt preserves the tested compact research and citation contract."""
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[real_tool],
         )
 
-        assert "If you use a tool result to answer" in agent.system_prompt
-        assert "exact tool name" in agent.system_prompt
-        assert "- [1] mcp_time__get_current_time" in agent.system_prompt
+        assert "your first response MUST be a tool call" in agent.system_prompt
+        assert "Cite every externally verified claim inline" in agent.system_prompt
+        assert "using an exact URL returned by a tool" in agent.system_prompt
 
     @pytest.mark.asyncio
     async def test_initial_answer_without_tool_call_is_retried(self, mock_llm_provider, mock_llm, real_tool):
@@ -675,8 +678,8 @@ class TestShallowResearcherSourceRegistryGating:
         )
 
     @pytest.mark.asyncio
-    async def test_missing_citation_fallback_skips_ambiguous_multi_source_registry(self, mock_llm_provider, mock_llm):
-        """Do not inject the first captured source when multiple sources exist."""
+    async def test_missing_citations_are_repaired_once_for_multiple_sources(self, mock_llm_provider, mock_llm):
+        """Ambiguous multi-source drafts get one bounded repair instead of a guessed citation."""
         populate_from_config(
             [
                 {
@@ -702,7 +705,10 @@ class TestShallowResearcherSourceRegistryGating:
             ],
         )
         final_response = AIMessage(content="CUDA is a parallel computing platform.")
-        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, final_response])
+        repaired_response = AIMessage(
+            content="CUDA is a parallel computing platform [2]. The current time came from the time tool [1]."
+        )
+        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, final_response, repaired_response])
 
         callback = MagicMock()
         agent = ShallowResearcherAgent(
@@ -718,8 +724,66 @@ class TestShallowResearcherSourceRegistryGating:
         assert len(sources) >= 2
         assert sources[0].citation_key == "mcp_time__get_current_time"
         assert any(source.url == "https://docs.nvidia.com/cuda/" for source in sources)
-        assert result.messages[-1].content == "CUDA is a parallel computing platform."
-        callback.emit_final_report.assert_called_once_with(result.messages[-1].content, cited_urls=[])
+        assert "CUDA is a parallel computing platform [2]" in result.messages[-1].content
+        assert "mcp_time__get_current_time" in result.messages[-1].content
+        callback.emit_final_report.assert_called_once_with(
+            result.messages[-1].content,
+            cited_urls=["https://docs.nvidia.com/cuda/"],
+        )
+        assert mock_llm.ainvoke.await_count == 3
+        repair_call = mock_llm.ainvoke.await_args_list[-1]
+        assert repair_call.kwargs["config"]["tags"] == [SUPPRESS_OUTPUT_ARTIFACT_TAG]
+        assert "do not call tools" in repair_call.args[0][-1].content
+        assert isinstance(repair_call.args[0][0], SystemMessage)
+
+    @pytest.mark.asyncio
+    async def test_failed_multi_source_repair_is_not_published(self, mock_llm_provider, mock_llm):
+        """A single unsuccessful repair fails closed without emitting an uncited report."""
+        populate_from_config(
+            [
+                {
+                    "id": "mcp_time",
+                    "name": "MCP Time",
+                    "description": "Get current time and timezone information through MCP.",
+                    "tools": ["mcp_time"],
+                },
+                {
+                    "id": "web_search",
+                    "name": "Web Search",
+                    "description": "Search the web for real-time information.",
+                    "tools": ["web_search_with_urls"],
+                },
+            ],
+            group_names={"mcp_time"},
+        )
+        tool_call_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "mcp_time__get_current_time", "args": {"timezone": "Asia/Tokyo"}, "id": "1"},
+                {"name": "web_search_with_urls", "args": {"query": "CUDA"}, "id": "2"},
+            ],
+        )
+        source_only_draft = AIMessage(
+            content=(
+                "CUDA is a parallel computing platform.\n\n"
+                "**References:**\n- [1] CUDA Toolkit Documentation - https://docs.nvidia.com/cuda/"
+            )
+        )
+        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, source_only_draft, source_only_draft])
+        callback = MagicMock()
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[mcp_time__get_current_time, web_search_with_urls],
+            callbacks=[callback],
+        )
+
+        with pytest.raises(CitationIntegrityError, match="citation_integrity_lost"):
+            await agent.run(
+                ShallowResearchAgentState(messages=[HumanMessage(content="What is CUDA? Also note the time.")])
+            )
+
+        assert mock_llm.ainvoke.await_count == 3
+        callback.emit_final_report.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_registered_exact_data_source_tool_without_urls_is_captured(self, mock_llm_provider, mock_llm):
@@ -830,7 +894,7 @@ class TestShallowResearcherSourceCaptureIntegration:
         """The final report body and authoritative URL set come from the same verification pass."""
         source_url = "https://docs.nvidia.com/cuda/"
         draft_report = f"CUDA is a parallel computing platform [1].\n\n## Sources\n[1] CUDA Docs: {source_url}"
-        verified_report = f"CUDA is a parallel computing platform.\n\n## Sources\n[1] CUDA Docs: {source_url}"
+        verified_report = draft_report
         tool_call_response = AIMessage(
             content="",
             tool_calls=[{"name": "web_search_with_urls", "args": {"query": "CUDA"}, "id": "1"}],
@@ -844,12 +908,12 @@ class TestShallowResearcherSourceCaptureIntegration:
         )
         first_verification = MagicMock(
             verified_report=draft_report,
-            valid_citations=[{"url": source_url}],
+            valid_citations=[{"number": 1, "url": source_url}],
             removed_citations=[],
         )
         final_verification = MagicMock(
             verified_report=verified_report,
-            valid_citations=[{"url": source_url}],
+            valid_citations=[{"number": 1, "url": source_url}],
             removed_citations=[],
         )
 
@@ -861,6 +925,37 @@ class TestShallowResearcherSourceCaptureIntegration:
 
         assert result.messages[-1].content == verified_report
         callback.emit_final_report.assert_called_once_with(verified_report, cited_urls=[source_url])
+
+    @pytest.mark.asyncio
+    async def test_finalization_cannot_publish_a_report_after_losing_inline_citations(
+        self, mock_llm_provider, mock_llm
+    ):
+        """A later sanitization regression must fail closed instead of publishing source-only prose."""
+        source_url = "https://docs.nvidia.com/cuda/"
+        cited_report = f"CUDA is a parallel computing platform [1].\n\n## Sources\n[1] CUDA Docs: {source_url}"
+        source_only_report = f"CUDA is a parallel computing platform.\n\n## Sources\n[1] CUDA Docs: {source_url}"
+        tool_call_response = AIMessage(
+            content="",
+            tool_calls=[{"name": "web_search_with_urls", "args": {"query": "CUDA"}, "id": "1"}],
+        )
+        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, AIMessage(content=cited_report)])
+        callback = MagicMock()
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[web_search_with_urls],
+            callbacks=[callback],
+        )
+
+        with (
+            patch(
+                "aiq_agent.agents.shallow_researcher.agent.sanitize_report",
+                return_value=MagicMock(sanitized_report=source_only_report),
+            ),
+            pytest.raises(CitationIntegrityError, match="citation_integrity_lost"),
+        ):
+            await agent.run(ShallowResearchAgentState(messages=[HumanMessage(content="What is CUDA?")]))
+
+        callback.emit_final_report.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_invalid_citation_removed_end_to_end(self, mock_llm_provider, mock_llm):
@@ -1128,6 +1223,13 @@ class TestAppendMinimalCitation:
 
     def test_no_leftover_header_passes_through(self):
         report = "Body sentence."
+
+        result = _append_minimal_citation(report, self._tool_source())
+
+        assert result == "Body sentence [1].\n\n**References:**\n- [1] mcp_time__get_current_time"
+
+    def test_replaces_source_only_section_and_adds_inline_marker(self):
+        report = "Body sentence.\n\n## Sources\n[1] mcp_time__get_current_time"
 
         result = _append_minimal_citation(report, self._tool_source())
 

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -348,7 +348,7 @@ class TestShallowResearcherAgent:
             call([real_tool]),
             call([real_tool], parallel_tool_calls=False),
         ]
-        for invocation in mock_llm.ainvoke.await_args_list[:2]:
+        for invocation in mock_llm.ainvoke.await_args_list:
             assert invocation.kwargs["config"] == {"tags": [SUPPRESS_OUTPUT_ARTIFACT_TAG]}
 
     @pytest.mark.asyncio
@@ -494,9 +494,11 @@ class TestShallowResearcherAgent:
     async def test_forced_synthesis_adds_instruction_message(self, mock_llm_provider, mock_llm, real_tool):
         """Test that forced synthesis adds instruction to synthesize."""
         captured_messages = []
+        captured_configs = []
 
-        async def capture_messages(messages):
+        async def capture_messages(messages, *, config):
             captured_messages.append(messages)
+            captured_configs.append(config)
             return AIMessage(content="Synthesized response")
 
         mock_llm.ainvoke = AsyncMock(side_effect=capture_messages)
@@ -521,6 +523,7 @@ class TestShallowResearcherAgent:
             "synthesize" in str(msg.content).lower() for msg in last_call_messages if hasattr(msg, "content")
         )
         assert synthesis_instruction_found
+        assert captured_configs == [{"tags": [SUPPRESS_OUTPUT_ARTIFACT_TAG]}]
 
 
 # ---------------------------------------------------------------------------
@@ -795,7 +798,12 @@ class TestShallowResearcherSourceRegistryGating:
         )
         final_response = AIMessage(content="CUDA is a parallel computing platform.")
         repaired_response = AIMessage(
-            content="CUDA is a parallel computing platform [2]. The current time came from the time tool [1]."
+            content=(
+                "CUDA is a parallel computing platform [2]. The current time came from the time tool [1].\n\n"
+                "**References:**\n"
+                "- [1] mcp_time__get_current_time\n"
+                "- [2] Source 2 - https://docs.nvidia.com/cuda/"
+            )
         )
         bound_llm = MagicMock()
         bound_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, final_response])
@@ -876,6 +884,8 @@ class TestShallowResearcherSourceRegistryGating:
             )
 
         assert mock_llm.ainvoke.await_count == 3
+        for invocation in mock_llm.ainvoke.await_args_list:
+            assert invocation.kwargs["config"]["tags"] == [SUPPRESS_OUTPUT_ARTIFACT_TAG]
         callback.emit_final_report.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1328,34 +1338,44 @@ class TestAppendMinimalCitation:
 
         assert result == "Body sentence [1].\n\n**References:**\n- [1] mcp_time__get_current_time"
 
-    @pytest.mark.parametrize(
-        "heading",
-        [
-            "###### References and notes",
-            "Sources:",
-            "**References:** selected sources",
-        ],
-    )
-    def test_replaces_supported_heading_variants(self, heading):
+    @pytest.mark.parametrize("heading", ["###### References", "Sources:", "**References:**"])
+    def test_replaces_canonical_heading_variants(self, heading):
         report = f"Body sentence.\n\n{heading}\n[1] mcp_time__get_current_time"
 
         result = _append_minimal_citation(report, self._tool_source())
 
-        assert heading not in result
+        assert result.count("**References:**") == 1
         assert result == "Body sentence [1].\n\n**References:**\n- [1] mcp_time__get_current_time"
+
+    @pytest.mark.parametrize(
+        "report",
+        [
+            "## Sources of renewable energy\nSolar is renewable.",
+            "## References to previous work\nPrior work remains relevant.",
+            "Sources: market revenue grew last year.",
+            "Sources:\nMarket revenue grew last year.",
+        ],
+    )
+    def test_preserves_source_like_answer_content(self, report):
+        result = _append_minimal_citation(report, self._tool_source())
+
+        assert report.removesuffix(".") in result
+        assert result.endswith("**References:**\n- [1] mcp_time__get_current_time")
+
+    def test_replaces_reference_definitions_without_discarding_trailing_answer(self):
+        report = "Opening answer.\n\n## References\n- [1] Old source - https://example.com/old\n\nClosing answer."
+
+        result = _append_minimal_citation(report, self._tool_source())
+
+        assert "Opening answer." in result
+        assert "Closing answer [1]." in result
+        assert "Old source" not in result
 
 
 class TestCitationIntegrity:
     """Tests for the final inline-plus-source publication invariant."""
 
-    @pytest.mark.parametrize(
-        "heading",
-        [
-            "###### References and notes",
-            "Sources:",
-            "**References:** selected sources",
-        ],
-    )
+    @pytest.mark.parametrize("heading", ["###### References", "Sources:", "**References:**"])
     def test_accepts_inline_marker_outside_reference_definitions(self, heading):
         report = f"{heading}\n- [1] Source - https://example.com/source\n\nAnswer [1]."
 
@@ -1370,3 +1390,14 @@ class TestCitationIntegrity:
         report = "[1] CUDA is a parallel computing platform.\n\nSources:\n- [1] CUDA - https://example.com/cuda"
 
         assert _has_citation_integrity(report, [{"number": 1, "url": "https://example.com/cuda"}])
+
+    def test_does_not_count_definitions_across_multiple_source_sections(self):
+        report = (
+            "Answer without a marker.\n\n"
+            "## Sources\n"
+            "- [1] First - https://example.com/first\n\n"
+            "## References\n"
+            "- [1] Second - https://example.com/second"
+        )
+
+        assert not _has_citation_integrity(report, [{"number": 1, "url": "https://example.com/first"}])

--- a/tests/aiq_agent/test_default_model_profiles.py
+++ b/tests/aiq_agent/test_default_model_profiles.py
@@ -19,6 +19,10 @@ CONFIG_GLOBS = (
 )
 CONFIG_PATHS = tuple(sorted(path for pattern in CONFIG_GLOBS for path in REPO_ROOT.glob(pattern)))
 FRESHQA_CONFIG_PATHS = tuple(sorted(REPO_ROOT.glob("frontends/benchmarks/freshqa/configs/*.yml")))
+SHALLOW_PROFILE_PATHS = (
+    REPO_ROOT / "configs/config_web_default_guardrails.yml",
+    REPO_ROOT / "configs/config_frontier_models.yml",
+)
 
 DEPRECATED_REFERENCES = (
     "/".join(("nvidia", "nemotron-3-super-120b-a12b")),
@@ -141,6 +145,15 @@ def test_freshqa_research_tools_are_registered_data_sources(config_path: Path):
             "deep_research_agent",
         }:
             assert set(function.get("tools", [])) <= source_tools
+
+
+@pytest.mark.parametrize("config_path", SHALLOW_PROFILE_PATHS, ids=lambda path: path.name)
+def test_shallow_profiles_use_the_shared_citation_prompt(config_path: Path):
+    """Default Lightning and frontier Luna must share the hardened prompt and runtime path."""
+    config = _load_config(config_path)
+    shallow = config["functions"]["shallow_research_agent"]
+
+    assert "system_prompt" not in shallow
 
 
 def test_deprecated_model_and_endpoint_references_are_absent():

--- a/tests/aiq_agent/test_default_model_profiles.py
+++ b/tests/aiq_agent/test_default_model_profiles.py
@@ -2,11 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
 
+from aiq_agent.agents.shallow_researcher.agent import ShallowResearcherAgent
+from aiq_agent.common import LLMProvider
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_SHALLOW_PROMPT = REPO_ROOT / "src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2"
 
 ULTRA_MODEL = "nvidia/nemotron-3-ultra-550b-a55b"
 LIGHTNING_MODEL = "nvidia/nemotron-3.5-lightning-30b-a3b"
@@ -152,8 +157,11 @@ def test_shallow_profiles_use_the_shared_citation_prompt(config_path: Path):
     """Default Lightning and frontier Luna must share the hardened prompt and runtime path."""
     config = _load_config(config_path)
     shallow = config["functions"]["shallow_research_agent"]
+    agent = ShallowResearcherAgent(llm_provider=MagicMock(spec=LLMProvider), tools=[])
 
+    assert shallow["_type"] == "shallow_research_agent"
     assert "system_prompt" not in shallow
+    assert agent.system_prompt == SHARED_SHALLOW_PROMPT.read_text(encoding="utf-8")
 
 
 def test_deprecated_model_and_endpoint_references_are_absent():


### PR DESCRIPTION
#### Overview

- preserve the existing `release/2.2` shallow-research prompt and add one targeted citation preflight reminder
- require every published researched answer to retain both a verified inline citation and a verified source section
- preserve deterministic single-source recovery; for ambiguous multi-source drafts, allow one bounded, tool-free citation repair and fail closed if integrity is still missing
- support both public-URL sources and uploaded-document citation keys such as `report.pdf, p.15`
- keep the behavior provider-agnostic so the default Lightning and frontier Luna profiles share the same hardened runtime path

Nemotron 3.5 Lightning can intermittently return a correct answer after successful research without inline citation markers or a source section. Prompting can reduce that failure rate, but it is not a product invariant. This change keeps the current research behavior intact and makes an uncited researched answer unpublishable.

#### DCO sign-off for the squash commit

Signed-off-by: Ajay Thorve <athorve@nvidia.com>

#### Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest -q tests/ sources/`: **2157 passed, 13 skipped**
- [x] prompt diff against `release/2.2` is one citation-preflight line; query rewriting, tool selection, source hierarchy, and answer style are unchanged
- [x] uploaded-document integration: an uncited multi-file `knowledge_search` summary invokes the bounded repair and publishes only with an inline marker plus verified filename/page citation key
- [x] citation-integrity parsing preserves valid answer lines that begin with an inline marker instead of treating them as reference definitions
- [x] Inference Hub shallow-workflow smoke on the final prompt/runtime: **5/5 Lightning** and **5/5 Luna** reports passed verified inline-plus-source checks
- [x] Lightning exercised the bounded repair path in **2/5** cases; both repaired reports passed the final integrity gate
- [x] Luna used the same shared prompt/runtime path and passed **5/5** without repair

The live smoke is a provider compatibility and citation-reliability check, not a replacement for the existing FreshQA quality benchmark.

#### Where should reviewers start?

1. `src/aiq_agent/agents/shallow_researcher/agent.py`: the final publication invariant, deterministic single-source fallback, and bounded multi-source repair
2. `tests/aiq_agent/agents/shallow_researcher/test_agent.py`: fail-closed, timeout, uploaded-document, source-heading, prefix-citation, and repair-path regression coverage
3. `tests/aiq_agent/test_default_model_profiles.py`: default Lightning and frontier Luna sharing the same hardened path
4. `src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2`: the single targeted prompt addition

#### Related Issues

- No public issue; fixes the shallow citation regression reported during 2.2 RC validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Research reports now provide more reliable inline citations and complete reference sections.
  * Missing or invalid citations are automatically repaired when possible using identified sources.
  * Citation repair is bounded to prevent delays, and reports with unresolved issues are prevented from being published with unsupported claims.
  * Citation handling now supports a broader range of source, heading, and reference formats.
  * Research responses continue to follow guidance for source prioritization, premise verification, concise answers, unverifiable claims, and uploaded-document research.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->