### PR TITLE
docs: finalize v2.2.0 release

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "README.md",
         "hashed_secret": "73140b88094aaf220a03532196b27b58a03c9b09",
         "is_verified": false,
-        "line_number": 408
+        "line_number": 414
       }
     ],
     "deploy/.env.example": [
@@ -355,5 +355,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T00:27:23Z"
+  "generated_at": "2026-08-17T17:33:50Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change Log
 
-Unreleased changes targeting AI-Q v2.2.0
+Release v2.2.0 (2026-08-17)
 
-These entries track candidate work on `release/2.2`. AI-Q `v2.1.0` remains the latest stable
-release; the candidate will be stabilized before the final `v2.2.0` release.
+Published NVIDIA NGC artifacts:
+
+- Backend container: [`nvcr.io/nvidia/blueprint/aiq-agent:2.2.0`](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/containers/aiq-agent/2.2.0)
+- Frontend container: [`nvcr.io/nvidia/blueprint/aiq-frontend:2.2.0`](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/containers/aiq-frontend/2.2.0)
+- Helm chart: [`nvidia/blueprint/aiq2-web:2.2.0`](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/helm-charts/aiq2-web/2.2.0)
 
 **Research and reports**
 
@@ -32,7 +35,7 @@ release; the candidate will be stabilized before the final `v2.2.0` release.
 
 **Deployment and observability**
 
-- The repository source Helm chart honors `helm install -n <namespace>` for every namespaced resource, including GitOps-rendered deployments; chart metadata advances to `aiq2-web` 2.1.1 with the `aiq` 0.0.5 dependency
+- The repository source Helm chart honors `helm install -n <namespace>` for every namespaced resource, including GitOps-rendered deployments; chart metadata advances to `aiq2-web` 2.2.0 with the `aiq` 0.0.5 dependency
 - NAT-exported async-job traces preserve configured workflow, task/batch, named-agent, and model/tool hierarchy across concurrent researchers without copying graph-state content into structural agent spans
 - Deep-research intake uses atomic per-principal, deployment-wide, and per-minute admission controls before Dask enqueue; each job also enforces hard input, runtime, plan, report, shared-state, query, note, todo, and source-tool budgets
 - Document ingestion enforces server-side file-count, per-file, aggregate-size, declared-type, and content validation using the same upload settings as the UI

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Recent changes include:
   chart honors the selected release namespace, and the UI improves concurrent-research activity,
   session recovery, and WebSocket reliability.
 
+AI-Q v2.2.0 is published on NVIDIA NGC as the
+[`aiq-agent` backend container](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/containers/aiq-agent/2.2.0),
+[`aiq-frontend` web container](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/containers/aiq-frontend/2.2.0),
+and [`aiq2-web` Helm chart](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/helm-charts/aiq2-web/2.2.0).
+Each artifact uses version `2.2.0`.
+
 See the [changelog](CHANGELOG.md) for detailed release history; the linked feature docs describe
 configuration and current limitations.
 

--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -13,6 +13,16 @@ The AI-Q blueprint supports multiple deployment methods. Choose the one that bes
 | [Kubernetes (Helm)](./kubernetes.md) | Multi-node clusters, production | Kubernetes cluster, Helm v3.x |
 | Manual (no containers) | Development and debugging | Python 3.11--3.13, system dependencies (refer to [Installation](../get-started/installation.md)) |
 
+## Published Release Artifacts
+
+AI-Q v2.2.0 is published on NVIDIA NGC. Use the exact versioned references below for release deployments.
+
+| Artifact | Type | Versioned reference |
+|----------|------|---------------------|
+| [`aiq-agent`](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/containers/aiq-agent/2.2.0) | Container image | `nvcr.io/nvidia/blueprint/aiq-agent:2.2.0` |
+| [`aiq-frontend`](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/containers/aiq-frontend/2.2.0) | Container image | `nvcr.io/nvidia/blueprint/aiq-frontend:2.2.0` |
+| [`aiq2-web`](https://catalog.ngc.nvidia.com/orgs/nvidia/blueprint/helm-charts/aiq2-web/2.2.0) | Helm chart | `nvidia/blueprint/aiq2-web:2.2.0` |
+
 ## Architecture Overview
 
 All containerized deployments run the same three services:


### PR DESCRIPTION
#### Overview

Finalize the AI-Q v2.2.0 release documentation for the 2026-08-17 release.

- Mark v2.2.0 as released in the changelog and replace the release-candidate wording.
- Link the published NVIDIA NGC backend image, frontend image, and Helm chart at version 2.2.0.
- Correct the changelog's stale Helm chart version from 2.1.1 to 2.2.0.
- Surface the exact published artifact references in the repository README and deployment documentation.
- Refresh the tracked secrets baseline line metadata after the README update.

The package version, Docker Compose defaults, Helm chart metadata and values, and docs publisher metadata were already set to 2.2.0 on `release/2.2` and remain unchanged.

#### DCO sign-off for the squash commit

Signed-off-by: Ajay Thorve <athorve@nvidia.com>
Signed-off-by: Ajay Thorve <AjayThorve@users.noreply.github.com>

#### Validation

- `uv run --extra docs sphinx-build -M html docs/source docs/build`
  - Passed; Sphinx built all 65 pages with three pre-existing unresolved cross-reference warnings.
- `helm lint deploy/helm/deployment-k8s`
  - Passed: 1 chart linted, 0 charts failed.
- `pre-commit run --files .secrets.baseline CHANGELOG.md README.md docs/source/deployment/index.md`
  - Passed all applicable hooks, including secret scanning and markdown link checking.
- Verified all three NVIDIA NGC v2.2.0 catalog URLs return HTTP 200.
- `git verify-commit a1d74dc1eef848abcdcd95011474bddb0b408825`
  - Good GPG signature from Ajay Thorve <athorve@nvidia.com>.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [ ] I added or updated tests for behavior changes. (Documentation-only release finalization; no behavior changed.)
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with `CHANGELOG.md`, then verify the NGC artifact table in `docs/source/deployment/index.md`.

#### Related Issues

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Release**
  - Released AI-Q v2.2.0.
  - Published NVIDIA NGC artifacts for the backend container, frontend container, and Helm chart.

- **Documentation**
  - Added links and references for the v2.2.0 release artifacts.
  - Updated the changelog with categorized release highlights across deployment, integrations, observability, user experience, and workflow improvements.
  - Updated deployment documentation with installation references for the published containers and Helm chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->