### PR TITLE
feat(ui): Deep Research nav rail, panel resize, and consolidated Citations

### DIFF
--- a/frontends/ui/README.md
+++ b/frontends/ui/README.md
@@ -105,7 +105,7 @@ src/
 ├── features/           # Business logic modules
 │   ├── chat/           # Chat functionality (components, hooks, store, types)
 │   ├── documents/      # File upload, validation, and persistence
-│   └── layout/         # App layout components (panels, tabs, navigation)
+│   └── layout/         # App layout components (panels, Deep Research rail, navigation)
 ├── hooks/              # Shared React hooks (PDF download, session URL)
 ├── lib/                # Utilities (PDF generation)
 ├── mocks/              # MSW mock handlers and database for testing
@@ -180,18 +180,29 @@ When you reopen a session after a page refresh:
 
 1. **ChatArea** - Displays immediately (messages, thinking steps loaded from localStorage)
 2. **PlanTab** - Displays immediately (plan messages loaded from localStorage)
-3. **Tasks/Thinking/Report tabs** - Shows loading state, then fetches data from the backend
+3. **Deep Research panels** - Show a loading state, then fetch their data from the backend
 
 The lazy loading is automatic and seamless - you don't need to do anything special.
 
-### Deep Research Progress
+### Deep Research Workspace
 
-The Tasks tab presents an append-only timeline of workflow phases that actually started.
-Repeated phase attempts share one row, concurrent researchers are aggregated with a
-completed/observed count, and missing phases are never inferred from later activity. The
-Thinking tab retains the detailed execution traces. For inactive legacy jobs without a
-recognized workflow trace, Tasks falls back to the root todo artifact. This projection is
-frontend-only and does not add model calls or change the backend event contract.
+Deep Research is driven by a persistent right-hand navigation rail. Each rail item opens a
+single panel to its left, and only one panel is open at a time:
+
+- **Data Sources** - Manage the connections and files the agent may read.
+- **Citations** - Every source the agent touched, consolidated behind an All / Cited
+  filter. Cited sources and the other sources found are listed together here; there is no
+  separate sources tab.
+- **Research** - The finished report, with the Markdown / PDF export footer.
+- **Thinking** - The reasoning and step trace. The workflow Task progress is folded in
+  here as a collapsible disclosure above the trace; there is no standalone Tasks tab and no
+  Artifacts panel.
+
+Task progress is an append-only timeline of workflow phases that actually started: repeated
+phase attempts share one row, concurrent researchers are aggregated with a
+completed/observed count, and missing phases are never inferred from later activity. This
+projection is frontend-only and does not add model calls or change the backend event
+contract.
 
 ## Docker Deployment
 

--- a/frontends/ui/src/features/chat/components/AgentResponse.spec.tsx
+++ b/frontends/ui/src/features/chat/components/AgentResponse.spec.tsx
@@ -195,6 +195,29 @@ describe('AgentResponse', () => {
     expect(mockOpenRightPanel).not.toHaveBeenCalled()
   })
 
+  test('clicking "View Progress" for an active job opens the Thinking panel, not the report placeholder', async () => {
+    const user = userEvent.setup()
+
+    render(<AgentResponse content="Working on it" jobId="job-active" isDeepResearchActive={true} />)
+
+    await user.click(screen.getByRole('button', { name: 'View Progress' }))
+
+    expect(mockOpenRightPanel).toHaveBeenCalledWith('thinking')
+    expect(mockOpenRightPanel).not.toHaveBeenCalledWith('research')
+    expect(mockSetResearchPanelTab).not.toHaveBeenCalled()
+  })
+
+  test('clicking "View Report" for a completed job loads the research report, not Thinking', async () => {
+    const user = userEvent.setup()
+
+    render(<AgentResponse content="Done" jobId="job-done" deepResearchJobStatus="success" />)
+
+    await user.click(screen.getByRole('button', { name: 'View Report' }))
+
+    expect(mockLoadResearchPanelTab).toHaveBeenCalledWith('job-done', 'report')
+    expect(mockOpenRightPanel).not.toHaveBeenCalledWith('thinking')
+  })
+
   test('strips a baked references block from the rendered body and lists sources', () => {
     const content =
       'NVIDIA shipped record volume [1].\n\n**References:**\n- [1] NVIDIA Q4 results - https://www.nvidia.com/news'

--- a/frontends/ui/src/features/chat/components/AgentResponse.tsx
+++ b/frontends/ui/src/features/chat/components/AgentResponse.tsx
@@ -96,8 +96,7 @@ export const AgentResponse: FC<AgentResponseProps> = ({
       if (!isDeepResearchStreaming || deepResearchJobId !== jobId) {
         await reconnectToActiveJob()
       }
-      setResearchPanelTab('tasks')
-      openRightPanel('research')
+      openRightPanel('thinking')
       return
     }
 

--- a/frontends/ui/src/features/chat/components/DeepResearchBanner.spec.tsx
+++ b/frontends/ui/src/features/chat/components/DeepResearchBanner.spec.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { render, screen } from '@/test-utils'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import { DeepResearchBanner } from './DeepResearchBanner'
 
@@ -37,6 +38,16 @@ describe('DeepResearchBanner', () => {
     render(<DeepResearchBanner bannerType="success" jobId="job-1" />)
 
     expect(screen.getByRole('button', { name: 'View Report' })).toBeInTheDocument()
+  })
+
+  test('clicking the completed banner action loads the research report and does not open Thinking', async () => {
+    const user = userEvent.setup()
+    render(<DeepResearchBanner bannerType="success" jobId="job-1" />)
+
+    await user.click(screen.getByRole('button', { name: 'View Report' }))
+
+    expect(mockLoadResearchPanelTab).toHaveBeenCalledWith('job-1', 'report')
+    expect(mockOpenRightPanel).not.toHaveBeenCalledWith('thinking')
   })
 
   test.each([

--- a/frontends/ui/src/features/chat/components/DeepResearchBanner.tsx
+++ b/frontends/ui/src/features/chat/components/DeepResearchBanner.tsx
@@ -126,7 +126,6 @@ export const DeepResearchBanner: FC<DeepResearchBannerProps> = ({
   timestamp,
 }) => {
   const openRightPanel = useLayoutStore((s) => s.openRightPanel)
-  const setResearchPanelTab = useLayoutStore((s) => s.setResearchPanelTab)
   const { loadResearchPanelTab } = useLoadJobData()
   const config = getBannerConfig(bannerType, jobId, { totalTokens, toolCallCount })
 
@@ -141,16 +140,8 @@ export const DeepResearchBanner: FC<DeepResearchBannerProps> = ({
       return
     }
 
-    setResearchPanelTab(buttonTab)
-    openRightPanel('research')
-  }, [
-    config.buttonTab,
-    openRightPanel,
-    setResearchPanelTab,
-    jobId,
-    loadResearchPanelTab,
-    isJobComplete,
-  ])
+    openRightPanel('thinking')
+  }, [config.buttonTab, openRightPanel, jobId, loadResearchPanelTab, isJobComplete])
 
   const actions =
     bannerType === 'success' && config.buttonText ? (

--- a/frontends/ui/src/features/layout/components/AppBar.spec.tsx
+++ b/frontends/ui/src/features/layout/components/AppBar.spec.tsx
@@ -72,7 +72,6 @@ describe('AppBar', () => {
     render(<AppBar isAuthenticated={false} />)
 
     expect(screen.getByRole('button', { name: /create new session/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /add data sources/i })).toBeDisabled()
     expect(screen.queryByRole('button', { name: /open documentation/i })).not.toBeInTheDocument()
   })
 
@@ -80,7 +79,6 @@ describe('AppBar', () => {
     render(<AppBar isAuthenticated={true} />)
 
     expect(screen.getByRole('button', { name: /create new session/i })).not.toBeDisabled()
-    expect(screen.getByRole('button', { name: /add data sources/i })).not.toBeDisabled()
     expect(screen.queryByRole('button', { name: /open documentation/i })).not.toBeInTheDocument()
   })
 
@@ -99,17 +97,14 @@ describe('AppBar', () => {
     render(<AppBar isAuthenticated={true} isNewSessionDisabled={true} />)
 
     expect(screen.getByRole('button', { name: /create new session/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /add data sources/i })).not.toBeDisabled()
   })
 
-  test('opens data-sources panel when Add Sources clicked', async () => {
-    const user = userEvent.setup()
-
+  test('does not render a Data Sources button (now lives in the Deep Research rail)', () => {
     render(<AppBar isAuthenticated={true} />)
 
-    await user.click(screen.getByRole('button', { name: /add data sources/i }))
-
-    expect(mockOpenRightPanel).toHaveBeenCalledWith('data-sources')
+    expect(screen.queryByRole('button', { name: /add data sources/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /data sources/i })).not.toBeInTheDocument()
+    expect(mockOpenRightPanel).not.toHaveBeenCalled()
   })
 
   test('toggles theme to dark from the app-bar toggle when in light/system mode', async () => {
@@ -233,7 +228,6 @@ describe('AppBar', () => {
       render(<AppBar isAuthenticated={true} authRequired={false} />)
 
       expect(screen.getByRole('button', { name: /create new session/i })).not.toBeDisabled()
-      expect(screen.getByRole('button', { name: /add data sources/i })).not.toBeDisabled()
       expect(screen.queryByRole('button', { name: /open documentation/i })).not.toBeInTheDocument()
     })
 

--- a/frontends/ui/src/features/layout/components/AppBar.tsx
+++ b/frontends/ui/src/features/layout/components/AppBar.tsx
@@ -17,9 +17,8 @@
 
 import { type FC, memo, useCallback, useEffect, useState } from 'react'
 import { Flex, Text, Button, Logo, Avatar, Popover, Divider } from '@/adapters/ui'
-import { Globe, Book, Lock, Logout, OpenExternal, Info, Moon, Sun } from '@/adapters/ui/icons'
+import { Book, Lock, Logout, OpenExternal, Info, Moon, Sun } from '@/adapters/ui/icons'
 import { useLayoutStore } from '../store'
-import { cn } from '@/shared/lib/cn'
 import type { ThemeMode } from '../types'
 
 interface AppBarProps {
@@ -59,8 +58,6 @@ export const AppBar: FC<AppBarProps> = memo(function AppBar({
   onSignIn,
   onSignOut,
 }) {
-  const rightPanel = useLayoutStore((s) => s.rightPanel)
-  const isDataSourcesOpen = rightPanel === 'data-sources'
   const theme = useLayoutStore((s) => s.theme)
   const setTheme = useLayoutStore((s) => s.setTheme)
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
@@ -79,16 +76,6 @@ export const AppBar: FC<AppBarProps> = memo(function AppBar({
   const toggleTheme = useCallback(() => {
     setTheme(isDarkMode ? 'light' : 'dark')
   }, [isDarkMode, setTheme])
-
-  const handleAddSourcesClick = useCallback(() => {
-    if (!isAuthenticated) return
-    const { rightPanel, closeRightPanel, openRightPanel } = useLayoutStore.getState()
-    if (rightPanel === 'data-sources') {
-      closeRightPanel()
-    } else {
-      openRightPanel('data-sources')
-    }
-  }, [isAuthenticated])
 
   const handleNewSessionClick = useCallback(() => {
     if (!isAuthenticated || isNewSessionDisabled) return
@@ -144,22 +131,6 @@ export const AppBar: FC<AppBarProps> = memo(function AppBar({
 
         {/* Right section: Actions + User */}
         <Flex align="center" gap="2" className="shrink-0">
-          <Button
-            kind="tertiary"
-            size="small"
-            onClick={handleAddSourcesClick}
-            disabled={!isAuthenticated}
-            aria-label="Add data sources"
-            aria-pressed={isDataSourcesOpen}
-            title="Add data sources"
-            className={cn(isDataSourcesOpen && 'brand-tint')}
-          >
-            <Flex align="center" gap="1">
-              <Globe className="h-4 w-4" />
-              <Text kind="label/regular/md">Data Sources</Text>
-            </Flex>
-          </Button>
-
           {/* Theme toggle: quick dark/light switch */}
           <Button
             kind="tertiary"

--- a/frontends/ui/src/features/layout/components/ChatArea.tsx
+++ b/frontends/ui/src/features/layout/components/ChatArea.tsx
@@ -237,7 +237,7 @@ export const ChatArea: FC<ChatAreaProps> = memo(function ChatArea({
           gap="8"
           className="mx-auto w-full max-w-4xl px-6 pb-28 pt-6"
         >
-          {turns.map((turn) => {
+          {turns.map((turn, index) => {
             const userMessage = turn.user
             const messageSteps = userMessage ? getStepsForUserMessage(userMessage.id) : []
             const hasThinkingSteps = messageSteps.length > 0
@@ -274,7 +274,7 @@ export const ChatArea: FC<ChatAreaProps> = memo(function ChatArea({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-                className="flex flex-col gap-3"
+                className={cn('flex flex-col gap-3', index > 0 && 'border-base border-t pt-8')}
               >
                 {userMessage && (
                   <MessageRenderer

--- a/frontends/ui/src/features/layout/components/DataSourcesPanel.spec.tsx
+++ b/frontends/ui/src/features/layout/components/DataSourcesPanel.spec.tsx
@@ -129,6 +129,14 @@ describe('DataSourcesPanel', () => {
     expect(screen.getByText('Data Sources')).toBeInTheDocument()
   })
 
+  test('header uses the shared header-height for rail alignment', () => {
+    const { container } = render(<DataSourcesPanel />)
+
+    const header = container.querySelector('.h-\\[var\\(--header-height\\)\\]')
+    expect(header).not.toBeNull()
+    expect(header).toHaveClass('h-[var(--header-height)]', 'shrink-0')
+  })
+
   test('renders connections tab by default', () => {
     render(<DataSourcesPanel />)
 

--- a/frontends/ui/src/features/layout/components/DataSourcesPanel.tsx
+++ b/frontends/ui/src/features/layout/components/DataSourcesPanel.tsx
@@ -265,7 +265,7 @@ export const DataSourcesPanel: FC<DataSourcesPanelProps> = memo(function DataSou
         <Flex
           align="center"
           justify="between"
-          className="border-base shrink-0 border-b py-4 pl-6 pr-4"
+          className="border-base h-[var(--header-height)] shrink-0 border-b pl-6 pr-4"
         >
           <Flex align="center" gap="2">
             <Globe className="h-5 w-5" />

--- a/frontends/ui/src/features/layout/components/DeepResearchRail.spec.tsx
+++ b/frontends/ui/src/features/layout/components/DeepResearchRail.spec.tsx
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@/test-utils'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+import { DeepResearchRail } from './DeepResearchRail'
+
+const mockOpenRightPanel = vi.fn()
+const mockCloseRightPanel = vi.fn()
+let mockRightPanel: string | null = null
+
+const railState = () => ({
+  rightPanel: mockRightPanel,
+  openRightPanel: mockOpenRightPanel,
+  closeRightPanel: mockCloseRightPanel,
+})
+
+vi.mock('../store', () => ({
+  useLayoutStore: Object.assign(
+    vi.fn((selector?: (s: ReturnType<typeof railState>) => unknown) => {
+      const state = railState()
+      return selector ? selector(state) : state
+    }),
+    { getState: () => railState() }
+  ),
+}))
+
+let mockIsDeepResearchStreaming = false
+
+vi.mock('@/features/chat', () => ({
+  useChatStore: (selector: (s: { isDeepResearchStreaming: boolean }) => unknown) =>
+    selector({ isDeepResearchStreaming: mockIsDeepResearchStreaming }),
+}))
+
+const ITEM_LABELS = ['Data Sources', 'Citations', 'Research', 'Thinking']
+
+describe('DeepResearchRail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRightPanel = null
+    mockIsDeepResearchStreaming = false
+  })
+
+  test('renders the header and all four nav items', () => {
+    render(<DeepResearchRail isAuthenticated={true} />)
+
+    expect(screen.getByText('Deep Research')).toBeInTheDocument()
+    for (const label of ITEM_LABELS) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+    }
+  })
+
+  test('does not render an Artifacts nav item', () => {
+    render(<DeepResearchRail isAuthenticated={true} />)
+
+    expect(screen.queryByRole('button', { name: 'Artifacts' })).not.toBeInTheDocument()
+  })
+
+  test('renders items in order with Thinking pinned at the bottom', () => {
+    render(<DeepResearchRail isAuthenticated={true} />)
+
+    const buttons = screen.getAllByRole('button').map((b) => b.getAttribute('aria-label'))
+    expect(buttons).toEqual(ITEM_LABELS)
+    expect(buttons[buttons.length - 1]).toBe('Thinking')
+  })
+
+  test('opens the matching panel when an item is clicked', async () => {
+    const user = userEvent.setup()
+    render(<DeepResearchRail isAuthenticated={true} />)
+
+    await user.click(screen.getByRole('button', { name: 'Citations' }))
+    expect(mockOpenRightPanel).toHaveBeenCalledWith('citations')
+
+    await user.click(screen.getByRole('button', { name: 'Thinking' }))
+    expect(mockOpenRightPanel).toHaveBeenCalledWith('thinking')
+  })
+
+  test('highlights the active item', () => {
+    mockRightPanel = 'research'
+    render(<DeepResearchRail isAuthenticated={true} />)
+
+    expect(screen.getByRole('button', { name: 'Research' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Citations' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+
+  test('clicking the active item closes its panel (toggle)', async () => {
+    mockRightPanel = 'research'
+    const user = userEvent.setup()
+    render(<DeepResearchRail isAuthenticated={true} />)
+
+    await user.click(screen.getByRole('button', { name: 'Research' }))
+
+    expect(mockCloseRightPanel).toHaveBeenCalled()
+    expect(mockOpenRightPanel).not.toHaveBeenCalled()
+  })
+
+  test('disables items and does nothing when unauthenticated', async () => {
+    const user = userEvent.setup()
+    render(<DeepResearchRail isAuthenticated={false} />)
+
+    const item = screen.getByRole('button', { name: 'Data Sources' })
+    expect(item).toBeDisabled()
+
+    await user.click(item)
+    expect(mockOpenRightPanel).not.toHaveBeenCalled()
+    expect(mockCloseRightPanel).not.toHaveBeenCalled()
+  })
+
+  test('enabled nav buttons use a pointer cursor', () => {
+    render(<DeepResearchRail isAuthenticated={true} />)
+
+    expect(screen.getByRole('button', { name: 'Research' })).toHaveClass('cursor-pointer')
+  })
+
+  test('disabled nav buttons keep the not-allowed cursor and are not pointer', () => {
+    render(<DeepResearchRail isAuthenticated={false} />)
+
+    const item = screen.getByRole('button', { name: 'Research' })
+    expect(item).toHaveClass('cursor-not-allowed')
+    expect(item).not.toHaveClass('cursor-pointer')
+  })
+
+  describe('deep research activity indicator', () => {
+    test('shows a live activity indicator while deep research is streaming', () => {
+      mockIsDeepResearchStreaming = true
+      render(<DeepResearchRail isAuthenticated={true} />)
+
+      expect(screen.getByTestId('deep-research-activity')).toBeInTheDocument()
+    })
+
+    test('hides the activity indicator when not streaming', () => {
+      mockIsDeepResearchStreaming = false
+      render(<DeepResearchRail isAuthenticated={true} />)
+
+      expect(screen.queryByTestId('deep-research-activity')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontends/ui/src/features/layout/components/DeepResearchRail.tsx
+++ b/frontends/ui/src/features/layout/components/DeepResearchRail.tsx
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * DeepResearchRail Component
+ *
+ * Persistent far-right vertical navigation for the Deep Research workspace.
+ * Each item toggles a content panel that opens immediately to its left:
+ *   - Data Sources, Citations, Research (primary group, top)
+ *   - Thinking (pinned to the bottom, visually separated)
+ *
+ * The active item gets a dark rounded highlight. Clicking the active item again
+ * closes its panel. The rail replaces the former "Show Research" vertical tab.
+ */
+
+'use client'
+
+import { type FC, type ComponentType, memo, useCallback } from 'react'
+import { Flex, Text } from '@/adapters/ui'
+import { ChartFlow, DocumentCheckmark, Document, Globe } from '@/adapters/ui/icons'
+import { cn } from '@/shared/lib/cn'
+import { useChatStore } from '@/features/chat'
+import { useLayoutStore } from '../store'
+import type { RightPanelType } from '../types'
+
+/** A single Deep Research rail entry. */
+export interface DeepResearchRailItem {
+  id: Exclude<RightPanelType, null | 'settings'>
+  label: string
+  Icon: ComponentType<{ className?: string }>
+}
+
+/** Primary rail items, rendered top-to-bottom above the Thinking item. */
+export const DEEP_RESEARCH_RAIL_ITEMS: DeepResearchRailItem[] = [
+  { id: 'data-sources', label: 'Data Sources', Icon: Globe },
+  { id: 'citations', label: 'Citations', Icon: DocumentCheckmark },
+  { id: 'research', label: 'Research', Icon: Document },
+]
+
+/** Thinking is pinned to the bottom of the rail, separated from the group. */
+export const DEEP_RESEARCH_THINKING_ITEM: DeepResearchRailItem = {
+  id: 'thinking',
+  label: 'Thinking',
+  Icon: ChartFlow,
+}
+
+const ALL_RAIL_ITEMS: DeepResearchRailItem[] = [
+  ...DEEP_RESEARCH_RAIL_ITEMS,
+  DEEP_RESEARCH_THINKING_ITEM,
+]
+
+/** Human label for a rail-backed right panel (used by the panel header). */
+export function getRailPanelLabel(panel: RightPanelType): string {
+  return ALL_RAIL_ITEMS.find((item) => item.id === panel)?.label ?? ''
+}
+
+interface DeepResearchRailProps {
+  /** Whether the user is authenticated; items are disabled otherwise. */
+  isAuthenticated?: boolean
+}
+
+interface RailButtonProps {
+  item: DeepResearchRailItem
+  isActive: boolean
+  isAuthenticated: boolean
+  onSelect: (id: DeepResearchRailItem['id']) => void
+}
+
+const RailButton: FC<RailButtonProps> = ({ item, isActive, isAuthenticated, onSelect }) => {
+  const { Icon, label, id } = item
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(id)}
+      disabled={!isAuthenticated}
+      aria-pressed={isActive}
+      aria-label={label}
+      title={isAuthenticated ? label : `Sign in to open ${label}`}
+      data-testid={`deep-research-rail-item-${id}`}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors',
+        isActive
+          ? 'bg-surface-sunken text-primary'
+          : 'text-secondary hover:bg-surface-raised-50 hover:text-primary',
+        isAuthenticated && 'cursor-pointer',
+        !isAuthenticated && 'cursor-not-allowed opacity-50 hover:bg-transparent'
+      )}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <Text kind="label/regular/md" className="truncate">
+        {label}
+      </Text>
+    </button>
+  )
+}
+
+/**
+ * The persistent Deep Research navigation rail.
+ */
+export const DeepResearchRail: FC<DeepResearchRailProps> = memo(function DeepResearchRail({
+  isAuthenticated = false,
+}) {
+  const rightPanel = useLayoutStore((s) => s.rightPanel)
+  const openRightPanel = useLayoutStore((s) => s.openRightPanel)
+  const closeRightPanel = useLayoutStore((s) => s.closeRightPanel)
+  const isDeepResearchStreaming = useChatStore((s) => s.isDeepResearchStreaming)
+
+  const handleSelect = useCallback(
+    (id: DeepResearchRailItem['id']) => {
+      if (!isAuthenticated) return
+      if (useLayoutStore.getState().rightPanel === id) {
+        closeRightPanel()
+      } else {
+        openRightPanel(id)
+      }
+    },
+    [isAuthenticated, openRightPanel, closeRightPanel]
+  )
+
+  return (
+    <nav
+      aria-label="Deep Research"
+      className="border-base bg-surface-base flex w-[180px] shrink-0 flex-col border-l"
+    >
+      <Flex
+        align="center"
+        gap="2"
+        className="border-base h-[var(--header-height)] shrink-0 border-b px-4"
+      >
+        <Text kind="label/semibold/md" className="text-primary whitespace-nowrap">
+          Deep Research
+        </Text>
+        {isDeepResearchStreaming && (
+          <span
+            data-testid="deep-research-activity"
+            role="status"
+            aria-label="Deep research in progress"
+            title="Deep research in progress"
+            className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-[color:var(--color-brand)] motion-reduce:animate-none"
+          />
+        )}
+      </Flex>
+
+      <Flex direction="col" justify="between" className="min-h-0 flex-1 p-3">
+        <Flex direction="col" gap="1">
+          {DEEP_RESEARCH_RAIL_ITEMS.map((item) => (
+            <RailButton
+              key={item.id}
+              item={item}
+              isActive={rightPanel === item.id}
+              isAuthenticated={isAuthenticated}
+              onSelect={handleSelect}
+            />
+          ))}
+        </Flex>
+
+        <Flex direction="col" gap="1" className="shrink-0">
+          <RailButton
+            item={DEEP_RESEARCH_THINKING_ITEM}
+            isActive={rightPanel === DEEP_RESEARCH_THINKING_ITEM.id}
+            isAuthenticated={isAuthenticated}
+            onSelect={handleSelect}
+          />
+        </Flex>
+      </Flex>
+    </nav>
+  )
+})

--- a/frontends/ui/src/features/layout/components/MainLayout.spec.tsx
+++ b/frontends/ui/src/features/layout/components/MainLayout.spec.tsx
@@ -100,6 +100,10 @@ vi.mock('./DataSourcesPanel', () => ({
   DataSourcesPanel: () => <div data-testid="data-sources-panel">Data Sources Panel</div>,
 }))
 
+vi.mock('./DeepResearchRail', () => ({
+  DeepResearchRail: () => <div data-testid="deep-research-rail">Deep Research Rail</div>,
+}))
+
 import { useChatStore } from '@/features/chat'
 
 describe('MainLayout', () => {
@@ -116,6 +120,7 @@ describe('MainLayout', () => {
     expect(screen.getByTestId('input-area')).toBeInTheDocument()
     expect(screen.getByTestId('research-panel')).toBeInTheDocument()
     expect(screen.getByTestId('data-sources-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('deep-research-rail')).toBeInTheDocument()
   })
 
   test('hides the sessions sidebar and data sources panel when unauthenticated', () => {
@@ -127,6 +132,7 @@ describe('MainLayout', () => {
     expect(screen.getByTestId('input-area')).toBeInTheDocument()
     expect(screen.getByTestId('research-panel')).toBeInTheDocument()
     expect(screen.queryByTestId('data-sources-panel')).not.toBeInTheDocument()
+    expect(screen.getByTestId('deep-research-rail')).toBeInTheDocument()
   })
 
   test('passes session title to AppBar', () => {
@@ -224,5 +230,13 @@ describe('MainLayout', () => {
 
     const centerColumn = screen.getByTestId('chat-area').parentElement
     expect(centerColumn).toHaveClass('flex-1')
+  })
+
+  test('chat region keeps a usable minimum width so panels cannot crush it', () => {
+    render(<MainLayout isAuthenticated={true} />)
+
+    const centerColumn = screen.getByTestId('chat-area').parentElement
+    expect(centerColumn).toHaveClass('min-w-[360px]')
+    expect(centerColumn).not.toHaveClass('min-w-0')
   })
 })

--- a/frontends/ui/src/features/layout/components/MainLayout.spec.tsx
+++ b/frontends/ui/src/features/layout/components/MainLayout.spec.tsx
@@ -97,7 +97,13 @@ vi.mock('./ResearchPanel', () => ({
 }))
 
 vi.mock('./DataSourcesPanel', () => ({
-  DataSourcesPanel: () => <div data-testid="data-sources-panel">Data Sources Panel</div>,
+  DataSourcesPanel: () => (
+    <div data-testid="data-sources-panel">
+      <button type="button" aria-label="Close data sources panel">
+        Close
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock('./DeepResearchRail', () => ({
@@ -232,11 +238,33 @@ describe('MainLayout', () => {
     expect(centerColumn).toHaveClass('flex-1')
   })
 
-  test('chat region keeps a usable minimum width so panels cannot crush it', () => {
-    render(<MainLayout isAuthenticated={true} />)
+  test('keeps the Deep Research rail and Data Sources close control reachable at 1024px instead of clipping them off-screen', () => {
+    const originalInnerWidth = window.innerWidth
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 })
+    try {
+      render(<MainLayout isAuthenticated={true} />)
 
-    const centerColumn = screen.getByTestId('chat-area').parentElement
-    expect(centerColumn).toHaveClass('min-w-[360px]')
-    expect(centerColumn).not.toHaveClass('min-w-0')
+      const contentRow = screen.getByTestId('main-content-row')
+      const rail = screen.getByTestId('deep-research-rail')
+      const closeControl = screen.getByRole('button', { name: 'Close data sources panel' })
+
+      expect(contentRow).toContainElement(rail)
+      expect(contentRow).toContainElement(closeControl)
+
+      expect(contentRow.className).toMatch(/overflow-x-auto/)
+      expect(contentRow.className).not.toMatch(/overflow-hidden/)
+
+      Object.defineProperty(contentRow, 'clientWidth', { configurable: true, value: 1024 })
+      Object.defineProperty(contentRow, 'scrollWidth', { configurable: true, value: 1240 })
+      expect(contentRow.scrollWidth).toBeGreaterThan(contentRow.clientWidth)
+
+      contentRow.scrollLeft = contentRow.scrollWidth - contentRow.clientWidth
+      expect(contentRow.scrollLeft).toBeGreaterThan(0)
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: originalInnerWidth,
+      })
+    }
   })
 })

--- a/frontends/ui/src/features/layout/components/MainLayout.tsx
+++ b/frontends/ui/src/features/layout/components/MainLayout.tsx
@@ -25,6 +25,7 @@ import { ChatArea } from './ChatArea'
 import { InputArea } from './InputArea'
 import { ResearchPanel } from './ResearchPanel'
 import { DataSourcesPanel } from './DataSourcesPanel'
+import { DeepResearchRail } from './DeepResearchRail'
 import { useChatStore, useDeepResearch, NoSourcesBanner } from '@/features/chat'
 import {
   hasActiveDeepResearchJob,
@@ -193,7 +194,7 @@ export const MainLayout: FC<MainLayoutProps> = ({
         )}
 
         {/* Center Content: Chat + Input */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex min-w-[360px] flex-1 flex-col overflow-hidden">
           {/* Chat Area - Scrollable */}
           <ChatArea isAuthenticated={isAuthenticated} isLoading={isLoading} onSignIn={onSignIn} />
 
@@ -208,8 +209,11 @@ export const MainLayout: FC<MainLayoutProps> = ({
         {/* Data Sources Panel (Right) - push panel */}
         {isAuthenticated && <DataSourcesPanel />}
 
-        {/* Research Panel (Right) - pushes content */}
+        {/* Deep Research content panel (Right) - pushes content, opens left of the rail */}
         <ResearchPanel isAuthenticated={isAuthenticated} />
+
+        {/* Deep Research rail (far Right) - persistent navigation */}
+        <DeepResearchRail isAuthenticated={isAuthenticated} />
       </div>
     </Flex>
   )

--- a/frontends/ui/src/features/layout/components/MainLayout.tsx
+++ b/frontends/ui/src/features/layout/components/MainLayout.tsx
@@ -179,7 +179,10 @@ export const MainLayout: FC<MainLayoutProps> = ({
       />
 
       {/* Main content area: in-flow panels reflow the center column (push, not overlay) */}
-      <div className="relative flex flex-1 overflow-hidden">
+      <div
+        data-testid="main-content-row"
+        className="relative flex flex-1 overflow-x-auto overflow-y-hidden"
+      >
         {/* Sessions Panel (Left) - collapsible push rail, only when authenticated */}
         {isAuthenticated && (
           <SessionsPanel

--- a/frontends/ui/src/features/layout/components/ReportTab.spec.tsx
+++ b/frontends/ui/src/features/layout/components/ReportTab.spec.tsx
@@ -70,6 +70,40 @@ describe('ReportTab', () => {
     expect(document.querySelector('svg')).toBeInTheDocument()
   })
 
+  test('shows an in-progress state when empty while deep research is streaming', () => {
+    vi.mocked(useChatStore).mockImplementation((selector?: (s: any) => any) => {
+      const state = {
+        reportContent: '',
+        isStreaming: true,
+        currentStatus: 'researching',
+        isDeepResearchStreaming: true,
+      }
+      return selector ? selector(state) : state
+    })
+
+    render(<ReportTab />)
+
+    expect(screen.getByText(/deep research in progress/i)).toBeInTheDocument()
+    expect(screen.queryByText(/report content will appear here/i)).not.toBeInTheDocument()
+  })
+
+  test('shows the static empty state when empty and not streaming', () => {
+    vi.mocked(useChatStore).mockImplementation((selector?: (s: any) => any) => {
+      const state = {
+        reportContent: '',
+        isStreaming: false,
+        currentStatus: null,
+        isDeepResearchStreaming: false,
+      }
+      return selector ? selector(state) : state
+    })
+
+    render(<ReportTab />)
+
+    expect(screen.getByText(/report content will appear here/i)).toBeInTheDocument()
+    expect(screen.queryByText(/deep research in progress/i)).not.toBeInTheDocument()
+  })
+
   test('renders report content via MarkdownRenderer', () => {
     vi.mocked(useChatStore).mockImplementation((selector?: (s: any) => any) => {
       const state = {

--- a/frontends/ui/src/features/layout/components/ReportTab.tsx
+++ b/frontends/ui/src/features/layout/components/ReportTab.tsx
@@ -37,15 +37,25 @@ interface ReportTabProps {
  * Renders research notes with a subtle preview treatment and the final report at full prominence.
  */
 export const ReportTab: FC<ReportTabProps> = ({ children }) => {
-  const { reportContent, reportContentCategory, isStreaming, currentStatus, deepResearchCitations, deepResearchFiles } =
-    useChatStore(useShallow((s) => ({
+  const {
+    reportContent,
+    reportContentCategory,
+    isStreaming,
+    currentStatus,
+    isDeepResearchStreaming,
+    deepResearchCitations,
+    deepResearchFiles,
+  } = useChatStore(
+    useShallow((s) => ({
       reportContent: s.reportContent,
       reportContentCategory: s.reportContentCategory,
       isStreaming: s.isStreaming,
       currentStatus: s.currentStatus,
+      isDeepResearchStreaming: s.isDeepResearchStreaming,
       deepResearchCitations: s.deepResearchCitations,
       deepResearchFiles: s.deepResearchFiles,
-    })))
+    }))
+  )
   // Resolve the owning job id (active or latest finished) so artifact:// images render.
   const deepResearchJobId = useChatStore(selectResolvedDeepResearchJobId)
 
@@ -76,12 +86,31 @@ export const ReportTab: FC<ReportTabProps> = ({ children }) => {
         {children ? (
           children
         ) : isEmpty ? (
-          <Flex direction="col" align="center" justify="center" className="flex-1 py-8 text-center">
-            <Document className="text-subtle mb-3 h-8 w-8" />
-            <Text kind="body/regular/md" className="text-subtle">
-              Report content will appear here when available.
-            </Text>
-          </Flex>
+          isDeepResearchStreaming ? (
+            <Flex
+              direction="col"
+              align="center"
+              justify="center"
+              gap="3"
+              className="flex-1 py-8 text-center"
+            >
+              <span
+                role="status"
+                aria-label="Deep research in progress"
+                className="h-2.5 w-2.5 animate-pulse rounded-full bg-[color:var(--color-brand)] motion-reduce:animate-none"
+              />
+              <Text kind="body/regular/md" className="text-secondary">
+                Deep research in progress...
+              </Text>
+            </Flex>
+          ) : (
+            <Flex direction="col" align="center" justify="center" className="flex-1 py-8 text-center">
+              <Document className="text-subtle mb-3 h-8 w-8" />
+              <Text kind="body/regular/md" className="text-subtle">
+                Report content will appear here when available.
+              </Text>
+            </Flex>
+          )
         ) : isResearchNotes ? (
           /* Research notes: preview treatment */
           <Flex direction="col" gap="3" className="flex-1">
@@ -92,7 +121,7 @@ export const ReportTab: FC<ReportTabProps> = ({ children }) => {
             >
               <div className="h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
               <Text kind="body/regular/sm" className="text-yellow-700 dark:text-yellow-300">
-                Research notes from agents — final report is still being generated.
+                Research notes from agents. Final report is still being generated.
               </Text>
             </Flex>
             <div className="flex-1 opacity-80">

--- a/frontends/ui/src/features/layout/components/ResearchPanel.spec.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchPanel.spec.tsx
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, screen } from '@/test-utils'
+import { render, screen, fireEvent, waitFor, act } from '@/test-utils'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, test, expect, beforeEach } from 'vitest'
-import { ResearchPanel } from './ResearchPanel'
+import { ResearchPanel, FALLBACK_WIDE_WIDTH } from './ResearchPanel'
 
 const mockCloseRightPanel = vi.fn()
 let mockRightPanel: string | null = 'research'
@@ -31,8 +31,13 @@ interface MockChatState {
   isDeepResearchStreaming: boolean
   deepResearchJobId: string | null
   reportContent: string
-  deepResearchCitations: Array<{ id: string; url: string; content: string; timestamp: Date }>
-  deepResearchFiles: Array<{ id: string; filename: string }>
+  deepResearchCitations: Array<{
+    id: string
+    url: string
+    content: string
+    timestamp: Date
+    isCited?: boolean
+  }>
   deepResearchAgents: unknown[]
   deepResearchTodos: unknown[]
 }
@@ -42,7 +47,6 @@ const defaultChatState: MockChatState = {
   deepResearchJobId: null,
   reportContent: '',
   deepResearchCitations: [],
-  deepResearchFiles: [],
   deepResearchAgents: [],
   deepResearchTodos: [],
 }
@@ -79,22 +83,18 @@ vi.mock('./ReportTab', () => ({
   ),
 }))
 
-vi.mock('./FileCard', () => ({
-  FileCard: ({ file }: { file: { filename: string } }) => (
-    <div data-testid="file-card">{file.filename}</div>
-  ),
-}))
-
 describe('ResearchPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRightPanel = 'research'
     mockChatState = { ...defaultChatState }
     mockIsLoadJobDataLoading = false
+    mockLoadResearchPanelTab.mockResolvedValue(undefined)
+    mockImportStreamOnly.mockResolvedValue(undefined)
   })
 
   describe('panel visibility', () => {
-    test.each(['research', 'thinking', 'citations', 'artifacts'] as const)(
+    test.each(['research', 'thinking', 'citations'] as const)(
       'is open for the %s rail panel',
       (panel) => {
         mockRightPanel = panel
@@ -121,7 +121,6 @@ describe('ResearchPanel', () => {
       ['research', 'Research'],
       ['thinking', 'Thinking'],
       ['citations', 'Citations'],
-      ['artifacts', 'Artifacts'],
     ] as const)('shows the %s label in the header', (panel, label) => {
       mockRightPanel = panel
       render(<ResearchPanel isAuthenticated={true} />)
@@ -183,7 +182,7 @@ describe('ResearchPanel', () => {
       mockRightPanel = 'citations'
       render(<ResearchPanel isAuthenticated={true} />)
 
-      expect(screen.getByText('Cited sources will appear here.')).toBeInTheDocument()
+      expect(screen.getByText('Sources the agent reads will appear here.')).toBeInTheDocument()
     })
 
     test('citations lists deep-research citations when present', () => {
@@ -201,27 +200,48 @@ describe('ResearchPanel', () => {
       }
       render(<ResearchPanel isAuthenticated={true} />)
 
-      expect(screen.getByText('A cited finding')).toBeInTheDocument()
-      expect(screen.queryByText('Cited sources will appear here.')).not.toBeInTheDocument()
+      expect(screen.getByText('example.com')).toBeInTheDocument()
+      expect(screen.queryByText('Sources the agent reads will appear here.')).not.toBeInTheDocument()
     })
 
-    test('artifacts shows an empty state when there are no files', () => {
-      mockRightPanel = 'artifacts'
-      render(<ResearchPanel isAuthenticated={true} />)
-
-      expect(screen.getByText('Artifacts will appear here.')).toBeInTheDocument()
-    })
-
-    test('artifacts lists generated files when present', () => {
-      mockRightPanel = 'artifacts'
+    test('citations consolidates cited and uncited sources behind the All/Cited filter', () => {
+      mockRightPanel = 'citations'
       mockChatState = {
         ...defaultChatState,
-        deepResearchFiles: [{ id: 'f1', filename: 'summary.md' }],
+        deepResearchCitations: [
+          {
+            id: 'read',
+            url: 'https://read.example',
+            content: 'Read but not cited',
+            timestamp: new Date('2026-05-01T00:00:00Z'),
+            isCited: false,
+          },
+          {
+            id: 'cited',
+            url: 'https://cited.example',
+            content: 'Cited in report',
+            timestamp: new Date('2026-05-02T00:00:00Z'),
+            isCited: true,
+          },
+        ],
       }
       render(<ResearchPanel isAuthenticated={true} />)
 
-      expect(screen.getByTestId('file-card')).toHaveTextContent('summary.md')
-      expect(screen.queryByText('Artifacts will appear here.')).not.toBeInTheDocument()
+      expect(screen.getAllByRole('radio').map((radio) => radio.textContent)).toEqual([
+        'All',
+        'Cited (1)',
+      ])
+      expect(screen.getByText('Cited in report')).toBeInTheDocument()
+      expect(screen.getByText('Other sources found')).toBeInTheDocument()
+      expect(screen.getByText('cited.example')).toBeInTheDocument()
+      expect(screen.getByText('read.example')).toBeInTheDocument()
+    })
+
+    test('does not render an artifacts panel', () => {
+      mockRightPanel = 'artifacts'
+      render(<ResearchPanel isAuthenticated={true} />)
+
+      expect(screen.getByTestId('research-panel')).toHaveAttribute('aria-hidden', 'true')
     })
   })
 
@@ -251,6 +271,172 @@ describe('ResearchPanel', () => {
       expect(screen.getByTestId('research-panel-stop')).toBeInTheDocument()
       expect(screen.getByTestId('research-panel-stop')).not.toBeDisabled()
     })
+
+    test('renders a divider between stop and close only while streaming', () => {
+      mockChatState = { ...defaultChatState, isDeepResearchStreaming: false }
+      const { unmount } = render(<ResearchPanel isAuthenticated={true} />)
+      expect(screen.queryByTestId('research-panel-header-divider')).not.toBeInTheDocument()
+      unmount()
+
+      mockChatState = { ...defaultChatState, isDeepResearchStreaming: true }
+      render(<ResearchPanel isAuthenticated={true} />)
+      expect(screen.getByTestId('research-panel-header-divider')).toBeInTheDocument()
+    })
+  })
+
+  describe('resize grip', () => {
+    const getPanelWidth = () =>
+      (screen.getByTestId('research-panel') as HTMLElement).style.width
+
+    test('exposes a resize separator only while the panel is open', () => {
+      mockRightPanel = 'research'
+      const { unmount } = render(<ResearchPanel isAuthenticated={true} />)
+      expect(screen.getByRole('separator', { name: 'Resize panel' })).toBeInTheDocument()
+      unmount()
+
+      mockRightPanel = null
+      render(<ResearchPanel isAuthenticated={true} />)
+      expect(screen.queryByTestId('research-panel-resize')).not.toBeInTheDocument()
+    })
+
+    test('nudges the width with the arrow keys', () => {
+      mockRightPanel = 'research'
+      render(<ResearchPanel isAuthenticated={true} />)
+      const grip = screen.getByRole('separator', { name: 'Resize panel' })
+
+      const expectedDefault = document.createElement('div')
+      expectedDefault.style.width = 'min(60%, 900px, 70vw)'
+      expect(getPanelWidth()).toBe(expectedDefault.style.width)
+
+      fireEvent.keyDown(grip, { key: 'ArrowLeft' })
+      const widened = getPanelWidth()
+      expect(widened).toMatch(/px$/)
+      expect(parseInt(widened, 10)).toBeGreaterThan(480)
+    })
+
+    test('clamps to the minimum width on repeated narrowing', () => {
+      mockRightPanel = 'research'
+      render(<ResearchPanel isAuthenticated={true} />)
+      const grip = screen.getByRole('separator', { name: 'Resize panel' })
+
+      for (let i = 0; i < 20; i++) {
+        fireEvent.keyDown(grip, { key: 'ArrowRight' })
+      }
+
+      expect(getPanelWidth()).toBe('480px')
+    })
+
+    test('clamps to the viewport-bounded maximum on repeated widening', () => {
+      mockRightPanel = 'research'
+      render(<ResearchPanel isAuthenticated={true} />)
+      const grip = screen.getByRole('separator', { name: 'Resize panel' })
+
+      for (let i = 0; i < 40; i++) {
+        fireEvent.keyDown(grip, { key: 'ArrowLeft' })
+      }
+
+      const max = Math.min(900, Math.round(window.innerWidth * 0.7))
+      expect(getPanelWidth()).toBe(`${max}px`)
+    })
+
+    test('tracks the pointer while dragging the grip', () => {
+      mockRightPanel = 'research'
+      render(<ResearchPanel isAuthenticated={true} />)
+      const grip = screen.getByRole('separator', { name: 'Resize panel' })
+
+      fireEvent.pointerDown(grip, { button: 0, clientX: 1000, pointerId: 1 })
+      fireEvent.pointerMove(grip, { clientX: 1100, pointerId: 1 })
+      fireEvent.pointerUp(grip, { clientX: 1100, pointerId: 1 })
+
+      expect(getPanelWidth()).toBe(`${FALLBACK_WIDE_WIDTH - 100}px`)
+    })
+
+    test('pointercancel clears the resizing state so resize does not stay stuck', () => {
+      mockRightPanel = 'research'
+      render(<ResearchPanel isAuthenticated={true} />)
+      const grip = screen.getByRole('separator', { name: 'Resize panel' })
+      const panel = screen.getByTestId('research-panel')
+
+      fireEvent.pointerDown(grip, { button: 0, clientX: 1000, pointerId: 1 })
+      expect(panel).toHaveClass('select-none')
+
+      fireEvent.pointerCancel(grip, { pointerId: 1 })
+      expect(panel).not.toHaveClass('select-none')
+
+      const widthAfterCancel = getPanelWidth()
+      fireEvent.pointerMove(grip, { clientX: 1200, pointerId: 1 })
+      expect(getPanelWidth()).toBe(widthAfterCancel)
+    })
+
+    test('exposes the resize range on the separator for assistive tech', () => {
+      mockRightPanel = 'research'
+      render(<ResearchPanel isAuthenticated={true} />)
+      const grip = screen.getByRole('separator', { name: 'Resize panel' })
+
+      expect(grip).toHaveAttribute('aria-valuemin')
+      expect(grip).toHaveAttribute('aria-valuemax')
+      expect(grip).toHaveAttribute('aria-valuenow')
+
+      const min = Number(grip.getAttribute('aria-valuemin'))
+      const max = Number(grip.getAttribute('aria-valuemax'))
+      const now = Number(grip.getAttribute('aria-valuenow'))
+      expect(min).toBeLessThan(max)
+      expect(now).toBeGreaterThanOrEqual(min)
+      expect(now).toBeLessThanOrEqual(max)
+    })
+
+    test('re-clamps a fixed panel width down to the new maximum when the viewport shrinks after a resize', () => {
+      mockRightPanel = 'research'
+      const originalInnerWidth = window.innerWidth
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1600 })
+      try {
+        render(<ResearchPanel isAuthenticated={true} />)
+        const grip = screen.getByRole('separator', { name: 'Resize panel' })
+
+        fireEvent.pointerDown(grip, { button: 0, clientX: 1500, pointerId: 1 })
+        fireEvent.pointerMove(grip, { clientX: 400, pointerId: 1 })
+        fireEvent.pointerUp(grip, { clientX: 400, pointerId: 1 })
+
+        const wideMax = Math.min(900, Math.round(1600 * 0.7))
+        expect(getPanelWidth()).toBe(`${wideMax}px`)
+
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 })
+        act(() => {
+          window.dispatchEvent(new Event('resize'))
+        })
+
+        const narrowMax = Math.min(900, Math.round(800 * 0.7))
+        expect(narrowMax).toBeLessThan(wideMax)
+        expect(getPanelWidth()).toBe(`${narrowMax}px`)
+      } finally {
+        Object.defineProperty(window, 'innerWidth', {
+          configurable: true,
+          value: originalInnerWidth,
+        })
+      }
+    })
+
+    test('keeps the resize range valid when the viewport is narrower than the panel min', () => {
+      mockRightPanel = 'research'
+      const originalInnerWidth = window.innerWidth
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 600 })
+      try {
+        render(<ResearchPanel isAuthenticated={true} />)
+        const grip = screen.getByRole('separator', { name: 'Resize panel' })
+
+        const min = Number(grip.getAttribute('aria-valuemin'))
+        const max = Number(grip.getAttribute('aria-valuemax'))
+        const now = Number(grip.getAttribute('aria-valuenow'))
+        expect(min).toBeLessThanOrEqual(max)
+        expect(now).toBeGreaterThanOrEqual(min)
+        expect(now).toBeLessThanOrEqual(max)
+      } finally {
+        Object.defineProperty(window, 'innerWidth', {
+          configurable: true,
+          value: originalInnerWidth,
+        })
+      }
+    })
   })
 
   describe('lazy data loading', () => {
@@ -268,6 +454,44 @@ describe('ResearchPanel', () => {
       render(<ResearchPanel isAuthenticated={true} />)
 
       expect(mockImportStreamOnly).toHaveBeenCalledWith('job-123')
+    })
+
+    test('loads once and does not re-attempt while the panel stays open, even across a loading toggle', async () => {
+      mockRightPanel = 'research'
+      mockChatState = { ...defaultChatState, deepResearchJobId: 'job-123' }
+
+      const { rerender } = render(<ResearchPanel isAuthenticated={true}>a</ResearchPanel>)
+      expect(mockLoadResearchPanelTab).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      mockIsLoadJobDataLoading = true
+      rerender(<ResearchPanel isAuthenticated={true}>b</ResearchPanel>)
+      mockIsLoadJobDataLoading = false
+      rerender(<ResearchPanel isAuthenticated={true}>c</ResearchPanel>)
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      expect(mockLoadResearchPanelTab).toHaveBeenCalledTimes(1)
+    })
+
+    test('reopening the panel for the same job re-loads (retry on fresh open)', async () => {
+      mockRightPanel = 'research'
+      mockChatState = { ...defaultChatState, deepResearchJobId: 'job-123' }
+
+      const { rerender } = render(<ResearchPanel isAuthenticated={true}>a</ResearchPanel>)
+      expect(mockLoadResearchPanelTab).toHaveBeenCalledTimes(1)
+
+      mockRightPanel = null
+      rerender(<ResearchPanel isAuthenticated={true}>b</ResearchPanel>)
+      mockRightPanel = 'research'
+      rerender(<ResearchPanel isAuthenticated={true}>c</ResearchPanel>)
+
+      await waitFor(() => expect(mockLoadResearchPanelTab).toHaveBeenCalledTimes(2))
     })
   })
 })

--- a/frontends/ui/src/features/layout/components/ResearchPanel.spec.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchPanel.spec.tsx
@@ -7,27 +7,13 @@ import { vi, describe, test, expect, beforeEach } from 'vitest'
 import { ResearchPanel } from './ResearchPanel'
 
 const mockCloseRightPanel = vi.fn()
-const mockOpenRightPanel = vi.fn()
-const mockSetResearchPanelTab = vi.fn()
 let mockRightPanel: string | null = 'research'
-let mockResearchPanelTab = 'tasks'
-
-interface MockLayoutSelectorState {
-  rightPanel: string | null
-  researchPanelTab: string
-  setResearchPanelTab: typeof mockSetResearchPanelTab
-  closeRightPanel: typeof mockCloseRightPanel
-  openRightPanel: typeof mockOpenRightPanel
-}
 
 vi.mock('../store', () => ({
-  useLayoutStore: vi.fn((selector?: (s: MockLayoutSelectorState) => unknown) => {
-    const state: MockLayoutSelectorState = {
+  useLayoutStore: vi.fn((selector?: (s: Record<string, unknown>) => unknown) => {
+    const state = {
       rightPanel: mockRightPanel,
-      researchPanelTab: mockResearchPanelTab,
-      setResearchPanelTab: mockSetResearchPanelTab,
       closeRightPanel: mockCloseRightPanel,
-      openRightPanel: mockOpenRightPanel,
     }
     return selector ? selector(state) : state
   }),
@@ -41,35 +27,41 @@ vi.mock('@/adapters/api', () => ({
   cancelJob: vi.fn().mockResolvedValue(undefined),
 }))
 
-let mockIsDeepResearchStreaming = false
-let mockDeepResearchJobId: string | null = null
-let mockDeepResearchStreamLoaded = false
-let mockIsLoadJobDataLoading = false
-const mockImportJobStream = vi.fn()
-const mockLoadResearchPanelTab = vi.fn()
+interface MockChatState {
+  isDeepResearchStreaming: boolean
+  deepResearchJobId: string | null
+  reportContent: string
+  deepResearchCitations: Array<{ id: string; url: string; content: string; timestamp: Date }>
+  deepResearchFiles: Array<{ id: string; filename: string }>
+  deepResearchAgents: unknown[]
+  deepResearchTodos: unknown[]
+}
 
-const mockCancelCurrentJob = vi.fn()
+const defaultChatState: MockChatState = {
+  isDeepResearchStreaming: false,
+  deepResearchJobId: null,
+  reportContent: '',
+  deepResearchCitations: [],
+  deepResearchFiles: [],
+  deepResearchAgents: [],
+  deepResearchTodos: [],
+}
+
+let mockChatState: MockChatState = { ...defaultChatState }
+let mockIsLoadJobDataLoading = false
+const mockLoadResearchPanelTab = vi.fn()
+const mockImportStreamOnly = vi.fn()
 
 vi.mock('@/features/chat', () => ({
-  useChatStore: (
-    selector: (state: {
-      isDeepResearchStreaming: boolean
-      deepResearchJobId: string | null
-      deepResearchStreamLoaded: boolean
-    }) => unknown
-  ) =>
-    selector({
-      isDeepResearchStreaming: mockIsDeepResearchStreaming,
-      deepResearchJobId: mockDeepResearchJobId,
-      deepResearchStreamLoaded: mockDeepResearchStreamLoaded,
-    }),
+  useChatStore: Object.assign(
+    (selector: (s: MockChatState) => unknown) => selector(mockChatState),
+    { getState: () => mockChatState }
+  ),
+  selectResolvedDeepResearchJobId: (s: MockChatState) => s.deepResearchJobId,
   useLoadJobData: () => ({
-    importStreamOnly: mockImportJobStream,
     loadResearchPanelTab: mockLoadResearchPanelTab,
+    importStreamOnly: mockImportStreamOnly,
     isLoading: mockIsLoadJobDataLoading,
-  }),
-  useDeepResearch: () => ({
-    cancelCurrentJob: mockCancelCurrentJob,
   }),
 }))
 
@@ -87,114 +79,155 @@ vi.mock('./ReportTab', () => ({
   ),
 }))
 
+vi.mock('./FileCard', () => ({
+  FileCard: ({ file }: { file: { filename: string } }) => (
+    <div data-testid="file-card">{file.filename}</div>
+  ),
+}))
+
 describe('ResearchPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRightPanel = 'research'
-    mockResearchPanelTab = 'tasks'
-    mockIsDeepResearchStreaming = false
-    mockDeepResearchJobId = null
-    mockDeepResearchStreamLoaded = false
+    mockChatState = { ...defaultChatState }
     mockIsLoadJobDataLoading = false
-    mockImportJobStream.mockClear()
-    mockLoadResearchPanelTab.mockClear()
   })
 
   describe('panel visibility', () => {
-    test('renders when rightPanel is "research"', () => {
-      mockRightPanel = 'research'
+    test.each(['research', 'thinking', 'citations', 'artifacts'] as const)(
+      'is open for the %s rail panel',
+      (panel) => {
+        mockRightPanel = panel
+        render(<ResearchPanel isAuthenticated={true} />)
 
+        expect(screen.getByTestId('research-panel-close')).toBeInTheDocument()
+        expect(screen.getByTestId('research-panel')).toHaveAttribute('aria-hidden', 'false')
+      }
+    )
+
+    test.each(['data-sources', 'settings', null] as const)(
+      'is hidden when rightPanel is %s',
+      (panel) => {
+        mockRightPanel = panel
+        render(<ResearchPanel isAuthenticated={true} />)
+
+        expect(screen.getByTestId('research-panel')).toHaveAttribute('aria-hidden', 'true')
+      }
+    )
+  })
+
+  describe('panel header', () => {
+    test.each([
+      ['research', 'Research'],
+      ['thinking', 'Thinking'],
+      ['citations', 'Citations'],
+      ['artifacts', 'Artifacts'],
+    ] as const)('shows the %s label in the header', (panel, label) => {
+      mockRightPanel = panel
       render(<ResearchPanel isAuthenticated={true} />)
 
-      expect(screen.getByTestId('research-panel-toggle')).toBeInTheDocument()
-      expect(screen.getByTestId('research-panel-close')).toBeInTheDocument()
+      expect(screen.getByText(label)).toBeInTheDocument()
     })
 
-    test('is hidden when rightPanel is null', () => {
-      mockRightPanel = null
+    test('does not render the former Tasks/Thinking/Report segmented control', () => {
+      render(<ResearchPanel isAuthenticated={true} />)
 
-      const { container } = render(<ResearchPanel isAuthenticated={true} />)
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+    })
 
-      const outerPanel = container.querySelector('[aria-hidden="true"]')
-      expect(outerPanel).toBeInTheDocument()
+    test('does not render the former "Show Research" toggle tab', () => {
+      render(<ResearchPanel isAuthenticated={true} />)
+
+      expect(screen.queryByText('Show Research')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('research-panel-toggle')).not.toBeInTheDocument()
     })
   })
 
-  describe('tab navigation', () => {
-    test('renders all tab options', () => {
+  describe('content wiring', () => {
+    test('research shows the ReportTab (with export footer)', () => {
+      mockRightPanel = 'research'
       render(<ResearchPanel isAuthenticated={true} />)
 
-      expect(screen.getByText('Tasks')).toBeInTheDocument()
-      expect(screen.getByText('Thinking')).toBeInTheDocument()
-      expect(screen.getByText('Report')).toBeInTheDocument()
-      expect(screen.queryByText('Plan')).not.toBeInTheDocument()
-      expect(screen.queryByText('Citations')).not.toBeInTheDocument()
+      expect(screen.getByTestId('report-tab')).toBeInTheDocument()
     })
 
-    test('calls setResearchPanelTab when tab is clicked', async () => {
-      const user = userEvent.setup()
-
+    test('thinking shows the ThinkingTab', () => {
+      mockRightPanel = 'thinking'
       render(<ResearchPanel isAuthenticated={true} />)
 
-      await user.click(screen.getByText('Thinking'))
-      expect(mockSetResearchPanelTab).toHaveBeenCalledWith('thinking')
-
-      await user.click(screen.getByText('Report'))
-      expect(mockSetResearchPanelTab).toHaveBeenCalledWith('report')
+      expect(screen.getByTestId('thinking-tab')).toBeInTheDocument()
     })
 
-    test('delegates report tab loading to the shared research panel loader', async () => {
-      mockDeepResearchJobId = 'job-123'
+    test('thinking folds workflow Task progress in when there is progress', async () => {
+      mockRightPanel = 'thinking'
+      mockChatState = { ...defaultChatState, deepResearchTodos: [{ id: 't1' }] }
       const user = userEvent.setup()
-
       render(<ResearchPanel isAuthenticated={true} />)
 
-      await user.click(screen.getByText('Report'))
+      const toggle = screen.getByText('Task progress')
+      expect(toggle).toBeInTheDocument()
+      expect(screen.queryByTestId('tasks-tab')).not.toBeInTheDocument()
 
-      expect(mockLoadResearchPanelTab).toHaveBeenCalledWith('job-123', 'report')
+      await user.click(toggle)
+      expect(screen.getByTestId('tasks-tab')).toBeInTheDocument()
     })
 
-    test('queues tab loading while another research panel load is active', async () => {
-      mockDeepResearchJobId = 'job-123'
-      mockIsLoadJobDataLoading = true
-      const user = userEvent.setup()
+    test('thinking hides Task progress when there is none', () => {
+      mockRightPanel = 'thinking'
+      render(<ResearchPanel isAuthenticated={true} />)
 
-      const { rerender } = render(<ResearchPanel isAuthenticated={true} />)
-
-      await user.click(screen.getByText('Report'))
-
-      expect(mockSetResearchPanelTab).toHaveBeenCalledWith('report')
-      expect(mockLoadResearchPanelTab).not.toHaveBeenCalled()
-
-      mockIsLoadJobDataLoading = false
-      rerender(<ResearchPanel isAuthenticated={true}>Reloaded</ResearchPanel>)
-
-      await vi.waitFor(() => {
-        expect(mockLoadResearchPanelTab).toHaveBeenCalledWith('job-123', 'report')
-      })
+      expect(screen.queryByText('Task progress')).not.toBeInTheDocument()
     })
 
-    test('displays correct tab content based on researchPanelTab', () => {
-      const tabs = ['tasks', 'thinking', 'report'] as const
-      for (const tab of tabs) {
-        mockResearchPanelTab = tab
-        const { unmount } = render(<ResearchPanel isAuthenticated={true} />)
-        expect(screen.getByTestId(`${tab}-tab`)).toBeInTheDocument()
-        unmount()
+    test('citations shows an empty state when there are no sources', () => {
+      mockRightPanel = 'citations'
+      render(<ResearchPanel isAuthenticated={true} />)
+
+      expect(screen.getByText('Cited sources will appear here.')).toBeInTheDocument()
+    })
+
+    test('citations lists deep-research citations when present', () => {
+      mockRightPanel = 'citations'
+      mockChatState = {
+        ...defaultChatState,
+        deepResearchCitations: [
+          {
+            id: 'c1',
+            url: 'https://example.com/report',
+            content: 'A cited finding',
+            timestamp: new Date('2026-05-01T00:00:00Z'),
+          },
+        ],
       }
+      render(<ResearchPanel isAuthenticated={true} />)
+
+      expect(screen.getByText('A cited finding')).toBeInTheDocument()
+      expect(screen.queryByText('Cited sources will appear here.')).not.toBeInTheDocument()
+    })
+
+    test('artifacts shows an empty state when there are no files', () => {
+      mockRightPanel = 'artifacts'
+      render(<ResearchPanel isAuthenticated={true} />)
+
+      expect(screen.getByText('Artifacts will appear here.')).toBeInTheDocument()
+    })
+
+    test('artifacts lists generated files when present', () => {
+      mockRightPanel = 'artifacts'
+      mockChatState = {
+        ...defaultChatState,
+        deepResearchFiles: [{ id: 'f1', filename: 'summary.md' }],
+      }
+      render(<ResearchPanel isAuthenticated={true} />)
+
+      expect(screen.getByTestId('file-card')).toHaveTextContent('summary.md')
+      expect(screen.queryByText('Artifacts will appear here.')).not.toBeInTheDocument()
     })
   })
 
   describe('close button', () => {
-    test('renders close button', () => {
-      render(<ResearchPanel isAuthenticated={true} />)
-
-      expect(screen.getByTestId('research-panel-close')).toBeInTheDocument()
-    })
-
-    test('calls closeRightPanel when close button clicked', async () => {
+    test('calls closeRightPanel when clicked', async () => {
       const user = userEvent.setup()
-
       render(<ResearchPanel isAuthenticated={true} />)
 
       await user.click(screen.getByTestId('research-panel-close'))
@@ -204,111 +237,37 @@ describe('ResearchPanel', () => {
   })
 
   describe('stop researching button', () => {
-    test('is always rendered', () => {
-      mockIsDeepResearchStreaming = false
+    test('is hidden when not streaming', () => {
+      mockChatState = { ...defaultChatState, isDeepResearchStreaming: false }
+      render(<ResearchPanel isAuthenticated={true} />)
 
+      expect(screen.queryByTestId('research-panel-stop')).not.toBeInTheDocument()
+    })
+
+    test('is shown and enabled when streaming', () => {
+      mockChatState = { ...defaultChatState, isDeepResearchStreaming: true }
       render(<ResearchPanel isAuthenticated={true} />)
 
       expect(screen.getByTestId('research-panel-stop')).toBeInTheDocument()
-    })
-
-    test('is disabled when not streaming', () => {
-      mockIsDeepResearchStreaming = false
-
-      render(<ResearchPanel isAuthenticated={true} />)
-
-      expect(screen.getByTestId('research-panel-stop')).toBeDisabled()
-    })
-
-    test('is enabled when streaming', () => {
-      mockIsDeepResearchStreaming = true
-
-      render(<ResearchPanel isAuthenticated={true} />)
-
       expect(screen.getByTestId('research-panel-stop')).not.toBeDisabled()
     })
   })
 
-  describe('streaming indicator', () => {
-    test('shows spinner in toggle tag when streaming', () => {
-      mockIsDeepResearchStreaming = true
-
-      render(<ResearchPanel isAuthenticated={true} />)
-
-      expect(screen.getByLabelText('Researching')).toBeInTheDocument()
-    })
-
-    test('shows generate icon when not streaming', () => {
-      mockIsDeepResearchStreaming = false
-
-      render(<ResearchPanel isAuthenticated={true} />)
-
-      expect(screen.queryByLabelText('Researching')).not.toBeInTheDocument()
-    })
-  })
-
-  describe('children rendering', () => {
-    test('passes children to ReportTab', () => {
-      mockResearchPanelTab = 'report'
-
-      render(
-        <ResearchPanel isAuthenticated={true}>
-          <div data-testid="custom-content">Custom Content</div>
-        </ResearchPanel>
-      )
-
-      expect(screen.getByTestId('custom-content')).toBeInTheDocument()
-    })
-  })
-
-  describe('segmented control groups', () => {
-    test('has all tab options', () => {
-      render(<ResearchPanel isAuthenticated={true} />)
-
-      expect(screen.getByText('Tasks')).toBeInTheDocument()
-      expect(screen.getByText('Thinking')).toBeInTheDocument()
-      expect(screen.getByText('Report')).toBeInTheDocument()
-      expect(screen.queryByText('Plan')).not.toBeInTheDocument()
-      expect(screen.queryByText('Citations')).not.toBeInTheDocument()
-    })
-  })
-
-  describe('toggle tag button', () => {
-    test('renders toggle tag button', () => {
-      render(<ResearchPanel isAuthenticated={true} />)
-
-      expect(screen.getByTestId('research-panel-toggle')).toBeInTheDocument()
-      expect(screen.getByText('Show Research')).toBeInTheDocument()
-    })
-
-    test('closes panel when tag clicked while open', async () => {
+  describe('lazy data loading', () => {
+    test('loads the report when the research panel opens for a job', () => {
       mockRightPanel = 'research'
-      const user = userEvent.setup()
-
+      mockChatState = { ...defaultChatState, deepResearchJobId: 'job-123' }
       render(<ResearchPanel isAuthenticated={true} />)
 
-      await user.click(screen.getByTestId('research-panel-toggle'))
-
-      expect(mockCloseRightPanel).toHaveBeenCalled()
+      expect(mockLoadResearchPanelTab).toHaveBeenCalledWith('job-123', 'report')
     })
 
-    test('toggle button is disabled when not authenticated', () => {
-      render(<ResearchPanel isAuthenticated={false} />)
+    test('replays the stream for stream-backed panels', () => {
+      mockRightPanel = 'thinking'
+      mockChatState = { ...defaultChatState, deepResearchJobId: 'job-123' }
+      render(<ResearchPanel isAuthenticated={true} />)
 
-      const toggleButton = screen.getByTestId('research-panel-toggle')
-      expect(toggleButton).toBeDisabled()
-      expect(toggleButton).toHaveAttribute('title', 'Sign in to access research panel')
-    })
-
-    test('toggle button does not trigger action when not authenticated', async () => {
-      mockRightPanel = null
-      const user = userEvent.setup()
-
-      render(<ResearchPanel isAuthenticated={false} />)
-
-      await user.click(screen.getByTestId('research-panel-toggle'))
-
-      expect(mockOpenRightPanel).not.toHaveBeenCalled()
+      expect(mockImportStreamOnly).toHaveBeenCalledWith('job-123')
     })
   })
 })

--- a/frontends/ui/src/features/layout/components/ResearchPanel.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchPanel.tsx
@@ -4,62 +4,191 @@
 /**
  * ResearchPanel Component
  *
- * Right-side panel showing Tasks, Thinking, or Report content.
- * Includes top action bar with tabs.
+ * The Deep Research content panel. It opens immediately to the left of the
+ * DeepResearchRail and swaps its content based on the active rail item:
+ *   - research  -> ReportTab (report + Markdown/PDF export footer)
+ *   - thinking  -> ThinkingTab (reasoning/steps trace) with the workflow Task
+ *                  progress folded in as a disclosure above it
+ *   - citations -> the report's cited sources (SourceStrip)
+ *   - artifacts -> the generated files/artifacts list (FileCard)
  *
- * This panel PUSHES the chat area (takes 60% width) rather than overlaying it.
+ * Data Sources is handled by its own DataSourcesPanel; the four items above and
+ * Data Sources are mutually exclusive via the shared rightPanel slot, so only
+ * one panel is ever open. This panel PUSHES the chat area rather than overlaying.
  */
 
 'use client'
 
-import { type FC, type ReactNode, memo, useCallback, useRef, useEffect } from 'react'
-import { Flex, Button, SegmentedControl, Spinner, Text } from '@/adapters/ui'
-import { Close, Generate, StopCircle } from '@/adapters/ui/icons'
+import { type FC, type ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Flex, Button, Spinner, Text } from '@/adapters/ui'
+import { CheckCircle, ChevronDown, Close, DocumentCheckmark, Image as ImageIcon, StopCircle } from '@/adapters/ui/icons'
 import { cancelJob } from '@/adapters/api'
-import { useChatStore, useLoadJobData } from '@/features/chat'
+import { useShallow } from 'zustand/react/shallow'
+import { cn } from '@/shared/lib/cn'
+import { useChatStore, useLoadJobData, selectResolvedDeepResearchJobId } from '@/features/chat'
 import { useAuth } from '@/adapters/auth'
 import { useReducedMotion } from '@/hooks/use-reduced-motion'
+import { SourceStrip } from '@/shared/components/Sources/SourceStrip'
+import { mapCitationSource } from '@/shared/components/Sources/source-utils'
+import { splitReferences } from '@/shared/components/Sources/parse-references'
 import { useLayoutStore } from '../store'
 import { TasksTab } from './TasksTab'
 import { ThinkingTab } from './ThinkingTab'
 import { ReportTab } from './ReportTab'
-import type { ResearchPanelTab } from '../types'
+import { FileCard } from './FileCard'
+import { getRailPanelLabel } from './DeepResearchRail'
+import type { RightPanelType } from '../types'
 
-const TABS_REQUIRING_STREAM: ResearchPanelTab[] = ['tasks', 'thinking']
+/** Rail panels rendered by this component (Data Sources lives in its own panel). */
+const PANEL_TABS = new Set<RightPanelType>(['research', 'thinking', 'citations', 'artifacts'])
+
+/** Panels that read replayed stream data (citations, files, steps). */
+const STREAM_BACKED_TABS = new Set<RightPanelType>(['thinking', 'citations', 'artifacts'])
+
+/** Wide panels get more room for their rich content. */
+const WIDE_TABS = new Set<RightPanelType>(['research', 'thinking'])
 
 /** Fallback timeout: if the SSE stream doesn't deliver the interrupted
  *  status within this window after cancel, clean up the UI optimistically. */
 const CANCEL_FALLBACK_TIMEOUT_MS = 5000
 
 interface ResearchPanelProps {
-  /** Content to display in the panel */
+  /** Content to display in the report view */
   children?: ReactNode
   /** Whether the user is authenticated */
   isAuthenticated?: boolean
 }
 
 /**
- * Research panel with tabbed content (Tasks, Thinking, Report).
- * Opens from the right side of the screen, pushing the chat area.
- * Takes 60% of the screen width when open.
+ * Report's cited sources, reusing the same data the report renders: parsed
+ * trailing references when present, otherwise the deep-research citations.
+ */
+const CitationsView: FC = () => {
+  const { reportContent, deepResearchCitations } = useChatStore(
+    useShallow((s) => ({
+      reportContent: s.reportContent,
+      deepResearchCitations: s.deepResearchCitations,
+    }))
+  )
+
+  const sources = useMemo(() => {
+    const reportContentStr = typeof reportContent === 'string' ? reportContent : ''
+    const split = splitReferences(reportContentStr)
+    if (split.sources.length > 0) return split.sources
+    return (deepResearchCitations ?? []).map(mapCitationSource)
+  }, [reportContent, deepResearchCitations])
+
+  if (sources.length === 0) {
+    return (
+      <Flex direction="col" align="center" justify="center" className="h-full py-8 text-center">
+        <DocumentCheckmark className="text-subtle mb-3 h-8 w-8" />
+        <Text kind="body/regular/md" className="text-subtle">
+          Cited sources will appear here.
+        </Text>
+      </Flex>
+    )
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <SourceStrip sources={sources} />
+    </div>
+  )
+}
+
+/**
+ * Generated artifacts/files produced by the deep-research flow.
+ */
+const ArtifactsView: FC = () => {
+  const deepResearchFiles = useChatStore((s) => s.deepResearchFiles)
+
+  if (!deepResearchFiles || deepResearchFiles.length === 0) {
+    return (
+      <Flex direction="col" align="center" justify="center" className="h-full py-8 text-center">
+        <ImageIcon className="text-subtle mb-3 h-8 w-8" />
+        <Text kind="body/regular/md" className="text-subtle">
+          Artifacts will appear here.
+        </Text>
+      </Flex>
+    )
+  }
+
+  return (
+    <Flex direction="col" gap="2" className="h-full overflow-y-auto">
+      {deepResearchFiles.map((file) => (
+        <div key={file.id} className="shrink-0">
+          <FileCard file={file} />
+        </div>
+      ))}
+    </Flex>
+  )
+}
+
+/**
+ * Thinking view: the reasoning/steps trace, with the observed workflow Task
+ * progress folded in as a collapsible disclosure above it (shown only when
+ * there is progress to display). This is where the former Tasks tab now lives.
+ */
+const ThinkingView: FC = () => {
+  const { deepResearchAgents, deepResearchTodos } = useChatStore(
+    useShallow((s) => ({
+      deepResearchAgents: s.deepResearchAgents,
+      deepResearchTodos: s.deepResearchTodos,
+    }))
+  )
+  const [showTasks, setShowTasks] = useState(false)
+  const hasTaskProgress = deepResearchAgents.length > 0 || deepResearchTodos.length > 0
+
+  return (
+    <Flex direction="col" gap="3" className="h-full min-h-0">
+      {hasTaskProgress && (
+        <Flex direction="col" gap="2" className="border-base shrink-0 border-b pb-3">
+          <button
+            type="button"
+            onClick={() => setShowTasks((v) => !v)}
+            aria-expanded={showTasks}
+            className="text-secondary hover:text-primary flex cursor-pointer items-center gap-1.5 self-start transition-colors"
+          >
+            <CheckCircle className="h-4 w-4" aria-hidden="true" />
+            <Text kind="body/regular/sm">Task progress</Text>
+            <ChevronDown
+              className={`h-4 w-4 transition-transform duration-200 ${showTasks ? 'rotate-180' : ''}`}
+              aria-hidden="true"
+            />
+          </button>
+          {showTasks && (
+            <div className="max-h-64 overflow-y-auto">
+              <TasksTab />
+            </div>
+          )}
+        </Flex>
+      )}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ThinkingTab />
+      </div>
+    </Flex>
+  )
+}
+
+/**
+ * The Deep Research content panel, driven by the rail selection.
  */
 export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel({
   children,
   isAuthenticated = false,
 }) {
-  const isOpen = useLayoutStore((s) => s.rightPanel === 'research')
-  const researchPanelTab = useLayoutStore((s) => s.researchPanelTab)
-  const setResearchPanelTab = useLayoutStore((s) => s.setResearchPanelTab)
+  const rightPanel = useLayoutStore((s) => s.rightPanel)
   const closeRightPanel = useLayoutStore((s) => s.closeRightPanel)
-  const openRightPanel = useLayoutStore((s) => s.openRightPanel)
-  const isDeepResearchStreaming = useChatStore((state) => state.isDeepResearchStreaming)
-  const deepResearchJobId = useChatStore((state) => state.deepResearchJobId)
-  const { loadResearchPanelTab, isLoading: isStreamLoading } = useLoadJobData()
+  const isOpen = PANEL_TABS.has(rightPanel)
+
+  const isDeepResearchStreaming = useChatStore((s) => s.isDeepResearchStreaming)
+  const deepResearchJobId = useChatStore(selectResolvedDeepResearchJobId)
+  const { loadResearchPanelTab, importStreamOnly, isLoading: isStreamLoading } = useLoadJobData()
   const { idToken } = useAuth()
 
   const prefersReducedMotion = useReducedMotion()
   const cancelFallbackRef = useRef<NodeJS.Timeout | null>(null)
-  const pendingTabLoadRef = useRef<{ jobId: string; tab: ResearchPanelTab } | null>(null)
+  const loadKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
     return () => {
@@ -71,16 +200,24 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
   }, [])
 
   useEffect(() => {
-    if (isStreamLoading) return
-
-    const pendingLoad = pendingTabLoadRef.current
-    if (!pendingLoad) return
-
-    pendingTabLoadRef.current = null
-    if (pendingLoad.jobId !== deepResearchJobId) return
-
-    void loadResearchPanelTab(pendingLoad.jobId, pendingLoad.tab)
-  }, [deepResearchJobId, isStreamLoading, loadResearchPanelTab])
+    if (!isAuthenticated || !isOpen || !deepResearchJobId || isStreamLoading) return
+    const key = `${rightPanel}:${deepResearchJobId}`
+    if (loadKeyRef.current === key) return
+    loadKeyRef.current = key
+    if (rightPanel === 'research') {
+      void loadResearchPanelTab(deepResearchJobId, 'report')
+    } else if (STREAM_BACKED_TABS.has(rightPanel)) {
+      void importStreamOnly(deepResearchJobId)
+    }
+  }, [
+    isAuthenticated,
+    isOpen,
+    rightPanel,
+    deepResearchJobId,
+    isStreamLoading,
+    loadResearchPanelTab,
+    importStreamOnly,
+  ])
 
   const handleClose = useCallback(() => {
     closeRightPanel()
@@ -123,190 +260,92 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
     }
   }, [deepResearchJobId, idToken])
 
-  const handleToggle = useCallback(() => {
-    if (!isAuthenticated) return
-
-    if (isOpen) {
-      closeRightPanel()
-    } else {
-      openRightPanel('research')
-
-      if (deepResearchJobId && !isStreamLoading) {
-        void loadResearchPanelTab(deepResearchJobId, researchPanelTab)
-      }
-    }
-  }, [
-    isAuthenticated,
-    isOpen,
-    closeRightPanel,
-    openRightPanel,
-    researchPanelTab,
-    deepResearchJobId,
-    isStreamLoading,
-    loadResearchPanelTab,
-  ])
-
-  const handleTabChange = useCallback(
-    (value: string) => {
-      const tab = value as ResearchPanelTab
-
-      if (deepResearchJobId && !isStreamLoading) {
-        void loadResearchPanelTab(deepResearchJobId, tab)
-        return
-      }
-
-      if (deepResearchJobId && isStreamLoading) {
-        pendingTabLoadRef.current = { jobId: deepResearchJobId, tab }
-      }
-
-      setResearchPanelTab(tab)
-    },
-    [setResearchPanelTab, deepResearchJobId, isStreamLoading, loadResearchPanelTab]
-  )
+  const isWide = WIDE_TABS.has(rightPanel)
+  const openWidth = isWide ? 'calc(60%)' : '420px'
+  const panelLabel = getRailPanelLabel(rightPanel)
 
   return (
     <div
-      className="relative flex h-full"
+      data-testid="research-panel"
+      className={cn('border-base bg-surface-base h-full shrink-0 overflow-hidden', isOpen && 'border-l')}
       style={{
-        width: isOpen ? 'calc(60% + 40px)' : '40px',
-        minWidth: isOpen ? 'calc(60% + 40px)' : '40px',
+        width: isOpen ? openWidth : '0px',
+        minWidth: isOpen ? (isWide ? '480px' : '420px') : '0px',
         transition: prefersReducedMotion
           ? 'none'
-          : 'width 600ms ease-in-out, min-width 600ms ease-in-out',
+          : 'width 400ms ease-in-out, min-width 400ms ease-in-out',
       }}
+      aria-hidden={!isOpen}
     >
-      {}
-      <button
-        onClick={handleToggle}
-        disabled={!isAuthenticated}
-        className={`research-panel-toggle border-base bg-surface-base relative z-10 flex w-10 shrink-0 items-center justify-center self-start overflow-hidden rounded-bl-lg border-b border-l border-r border-t transition-colors ${
-          isAuthenticated
-            ? 'cursor-pointer hover:border-brand'
-            : 'cursor-not-allowed opacity-50'
-        }`}
-        style={{ height: 'calc(var(--spacing) * 38)' }}
-        aria-label={isOpen ? 'Close research panel' : 'Open research panel'}
-        aria-expanded={isOpen}
-        title={
-          isAuthenticated
-            ? isOpen
-              ? 'Close research panel'
-              : 'Open research panel'
-            : 'Sign in to access research panel'
-        }
-        data-testid="research-panel-toggle"
+      <Flex
+        direction="col"
+        className="h-full w-full"
+        style={{
+          visibility: isOpen ? 'visible' : 'hidden',
+          opacity: isOpen ? 1 : 0,
+          transition: prefersReducedMotion
+            ? 'none'
+            : isOpen
+              ? 'opacity 100ms ease-in-out, visibility 0ms'
+              : 'opacity 100ms ease-in-out 300ms, visibility 0ms 400ms',
+        }}
       >
-        <span
-          className="absolute left-1/2 flex -translate-x-1/2 items-center justify-center"
-          style={{
-            top: 'calc(var(--spacing) * 3)',
-            width: 'calc(var(--spacing) * 6)',
-            height: 'calc(var(--spacing) * 6)',
-          }}
-        >
-          {isDeepResearchStreaming ? (
-            <Spinner size="small" aria-label="Researching" />
-          ) : (
-            <Generate className="h-[calc(var(--spacing)*6)] w-[calc(var(--spacing)*6)]" />
-          )}
-        </span>
-        <Text
-          kind="label/semibold/sm"
-          className="text-primary absolute left-1/2 -translate-x-1/2 -rotate-90 whitespace-nowrap"
-          style={{ top: 'calc(var(--spacing) * 21)' }}
-        >
-          Show Research
-        </Text>
-      </button>
-
-      {}
-      <div
-        className={`border-base bg-surface-base -ml-px h-full flex-1 overflow-hidden rounded-bl-xl ${
-          isOpen ? 'border-l' : ''
-        }`}
-        aria-hidden={!isOpen}
-      >
-        {}
+        {/* Header: active item name + optional stop + close */}
         <Flex
-          direction="col"
-          className="h-full w-full"
-          style={{
-            visibility: isOpen ? 'visible' : 'hidden',
-            opacity: isOpen ? 1 : 0,
-            transition: prefersReducedMotion
-              ? 'none'
-              : isOpen
-                ? 'opacity 100ms ease-in-out, visibility 0ms'
-                : 'opacity 100ms ease-in-out 500ms, visibility 0ms 600ms',
-          }}
+          align="center"
+          justify="between"
+          className="border-base h-[var(--header-height)] shrink-0 border-b px-6"
         >
-          {}
-          <Flex
-            align="center"
-            justify="between"
-            className="border-base shrink-0 border-b py-4 pl-6 pr-8"
-          >
-            <Flex align="center" gap="density-xl">
-              <SegmentedControl
-                value={researchPanelTab}
-                onValueChange={handleTabChange}
-                size="medium"
-                items={[
-                  { value: 'tasks', children: 'Tasks' },
-                  { value: 'thinking', children: 'Thinking' },
-                  { value: 'report', children: 'Report' },
-                ]}
-              />
-              {}
+          <Text kind="label/semibold/md" className="text-primary truncate">
+            {panelLabel}
+          </Text>
+          <Flex align="center" gap="2">
+            {isDeepResearchStreaming && (
               <Button
                 kind="tertiary"
                 size="small"
-                onClick={isDeepResearchStreaming ? handleStopResearch : undefined}
-                disabled={!isDeepResearchStreaming}
+                onClick={handleStopResearch}
                 aria-label="Stop researching"
-                title={isDeepResearchStreaming ? 'Stop researching' : 'No active research'}
+                title="Stop researching"
                 data-testid="research-panel-stop"
               >
                 <StopCircle className="mr-2 h-4 w-4" aria-hidden="true" />
                 Stop Researching
               </Button>
-            </Flex>
-            <Flex align="center" gap="density-xl">
-              {}
-              <Button
-                kind="tertiary"
-                size="small"
-                onClick={handleClose}
-                aria-label="Close research panel"
-                title="Close research panel"
-                data-testid="research-panel-close"
-              >
-                <Close className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            </Flex>
-          </Flex>
-
-          {}
-          <Flex direction="col" className="flex-1 overflow-hidden py-5 pl-6 pr-8">
-            {isStreamLoading ? (
-              <Flex direction="col" align="center" justify="center" className="h-full gap-4">
-                <Spinner size="medium" aria-label="Loading research data" />
-                <Text kind="body/regular/md" className="text-tertiary">
-                  {TABS_REQUIRING_STREAM.includes(researchPanelTab)
-                    ? 'Loading research data...'
-                    : 'Loading report...'}
-                </Text>
-              </Flex>
-            ) : (
-              <>
-                {researchPanelTab === 'tasks' && <TasksTab />}
-                {researchPanelTab === 'thinking' && <ThinkingTab />}
-                {researchPanelTab === 'report' && <ReportTab>{children}</ReportTab>}
-              </>
             )}
+            <Button
+              kind="tertiary"
+              size="small"
+              onClick={handleClose}
+              aria-label={`Close ${panelLabel || 'panel'}`}
+              title="Close panel"
+              data-testid="research-panel-close"
+            >
+              <Close className="h-4 w-4" aria-hidden="true" />
+            </Button>
           </Flex>
         </Flex>
-      </div>
+
+        {/* Body */}
+        <Flex direction="col" className="flex-1 overflow-hidden px-6 py-5">
+          {isStreamLoading ? (
+            <Flex direction="col" align="center" justify="center" className="h-full gap-4">
+              <Spinner size="medium" aria-label="Loading research data" />
+              <Text kind="body/regular/md" className="text-tertiary">
+                {rightPanel === 'research' ? 'Loading report...' : 'Loading research data...'}
+              </Text>
+            </Flex>
+          ) : rightPanel === 'research' ? (
+            <ReportTab>{children}</ReportTab>
+          ) : rightPanel === 'thinking' ? (
+            <ThinkingView />
+          ) : rightPanel === 'citations' ? (
+            <CitationsView />
+          ) : rightPanel === 'artifacts' ? (
+            <ArtifactsView />
+          ) : null}
+        </Flex>
+      </Flex>
     </div>
   )
 })

--- a/frontends/ui/src/features/layout/components/ResearchPanel.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchPanel.tsx
@@ -181,7 +181,7 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
         disabled={!isAuthenticated}
         className={`research-panel-toggle border-base bg-surface-base relative z-10 flex w-10 shrink-0 items-center justify-center self-start overflow-hidden rounded-bl-lg border-b border-l border-r border-t transition-colors ${
           isAuthenticated
-            ? 'cursor-pointer hover:border-[#76B900]'
+            ? 'cursor-pointer hover:border-brand'
             : 'cursor-not-allowed opacity-50'
         }`}
         style={{ height: 'calc(var(--spacing) * 38)' }}

--- a/frontends/ui/src/features/layout/components/ResearchPanel.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchPanel.tsx
@@ -9,119 +9,89 @@
  *   - research  -> ReportTab (report + Markdown/PDF export footer)
  *   - thinking  -> ThinkingTab (reasoning/steps trace) with the workflow Task
  *                  progress folded in as a disclosure above it
- *   - citations -> the report's cited sources (SourceStrip)
- *   - artifacts -> the generated files/artifacts list (FileCard)
+ *   - citations -> every source the agent touched (ResearchSourcesView)
  *
- * Data Sources is handled by its own DataSourcesPanel; the four items above and
+ * Data Sources is handled by its own DataSourcesPanel; the three items above and
  * Data Sources are mutually exclusive via the shared rightPanel slot, so only
- * one panel is ever open. This panel PUSHES the chat area rather than overlaying.
+ * one panel is ever open. This panel PUSHES the chat area rather than overlaying
+ * and exposes a drag/keyboard resize grip on its left (chat-facing) edge.
  */
 
 'use client'
 
-import { type FC, type ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type FC,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { Flex, Button, Spinner, Text } from '@/adapters/ui'
-import { CheckCircle, ChevronDown, Close, DocumentCheckmark, Image as ImageIcon, StopCircle } from '@/adapters/ui/icons'
+import { CheckCircle, ChevronDown, Close, StopCircle } from '@/adapters/ui/icons'
 import { cancelJob } from '@/adapters/api'
 import { useShallow } from 'zustand/react/shallow'
 import { cn } from '@/shared/lib/cn'
 import { useChatStore, useLoadJobData, selectResolvedDeepResearchJobId } from '@/features/chat'
 import { useAuth } from '@/adapters/auth'
 import { useReducedMotion } from '@/hooks/use-reduced-motion'
-import { SourceStrip } from '@/shared/components/Sources/SourceStrip'
-import { mapCitationSource } from '@/shared/components/Sources/source-utils'
-import { splitReferences } from '@/shared/components/Sources/parse-references'
 import { useLayoutStore } from '../store'
 import { TasksTab } from './TasksTab'
 import { ThinkingTab } from './ThinkingTab'
 import { ReportTab } from './ReportTab'
-import { FileCard } from './FileCard'
+import { ResearchSourcesView } from './ResearchSourcesView'
 import { getRailPanelLabel } from './DeepResearchRail'
 import type { RightPanelType } from '../types'
 
 /** Rail panels rendered by this component (Data Sources lives in its own panel). */
-const PANEL_TABS = new Set<RightPanelType>(['research', 'thinking', 'citations', 'artifacts'])
+const PANEL_TABS = new Set<RightPanelType>(['research', 'thinking', 'citations'])
 
-/** Panels that read replayed stream data (citations, files, steps). */
-const STREAM_BACKED_TABS = new Set<RightPanelType>(['thinking', 'citations', 'artifacts'])
+/** Panels that read replayed stream data (citations, steps). */
+const STREAM_BACKED_TABS = new Set<RightPanelType>(['thinking', 'citations'])
 
 /** Wide panels get more room for their rich content. */
 const WIDE_TABS = new Set<RightPanelType>(['research', 'thinking'])
 
+/** Minimum open width per panel class (px). */
+const WIDE_MIN_WIDTH = 480
+const NARROW_MIN_WIDTH = 420
+
+/** Upper bounds so a resized panel never covers the whole viewport. */
+const MAX_WIDTH_PX = 900
+const MAX_WIDTH_VW_RATIO = 0.7
+
+/** Nudge step for keyboard resize (px). */
+const KEYBOARD_STEP_PX = 24
+
+/** Width used as the drag/keyboard start when the live panel size is unknown. */
+export const FALLBACK_WIDE_WIDTH = 640
+
 /** Fallback timeout: if the SSE stream doesn't deliver the interrupted
  *  status within this window after cancel, clean up the UI optimistically. */
 const CANCEL_FALLBACK_TIMEOUT_MS = 5000
+
+/** Largest allowed width for the current viewport. */
+const getMaxWidth = (): number => {
+  if (typeof window === 'undefined') return MAX_WIDTH_PX
+  return Math.min(MAX_WIDTH_PX, Math.round(window.innerWidth * MAX_WIDTH_VW_RATIO))
+}
+
+/** Clamp a proposed width to the active panel's [min, max] range. */
+const clampPanelWidth = (px: number, wide: boolean): number => {
+  const min = wide ? WIDE_MIN_WIDTH : NARROW_MIN_WIDTH
+  const max = getMaxWidth()
+  const lo = Math.min(min, max)
+  return Math.max(lo, Math.min(Math.round(px), max))
+}
 
 interface ResearchPanelProps {
   /** Content to display in the report view */
   children?: ReactNode
   /** Whether the user is authenticated */
   isAuthenticated?: boolean
-}
-
-/**
- * Report's cited sources, reusing the same data the report renders: parsed
- * trailing references when present, otherwise the deep-research citations.
- */
-const CitationsView: FC = () => {
-  const { reportContent, deepResearchCitations } = useChatStore(
-    useShallow((s) => ({
-      reportContent: s.reportContent,
-      deepResearchCitations: s.deepResearchCitations,
-    }))
-  )
-
-  const sources = useMemo(() => {
-    const reportContentStr = typeof reportContent === 'string' ? reportContent : ''
-    const split = splitReferences(reportContentStr)
-    if (split.sources.length > 0) return split.sources
-    return (deepResearchCitations ?? []).map(mapCitationSource)
-  }, [reportContent, deepResearchCitations])
-
-  if (sources.length === 0) {
-    return (
-      <Flex direction="col" align="center" justify="center" className="h-full py-8 text-center">
-        <DocumentCheckmark className="text-subtle mb-3 h-8 w-8" />
-        <Text kind="body/regular/md" className="text-subtle">
-          Cited sources will appear here.
-        </Text>
-      </Flex>
-    )
-  }
-
-  return (
-    <div className="h-full overflow-y-auto">
-      <SourceStrip sources={sources} />
-    </div>
-  )
-}
-
-/**
- * Generated artifacts/files produced by the deep-research flow.
- */
-const ArtifactsView: FC = () => {
-  const deepResearchFiles = useChatStore((s) => s.deepResearchFiles)
-
-  if (!deepResearchFiles || deepResearchFiles.length === 0) {
-    return (
-      <Flex direction="col" align="center" justify="center" className="h-full py-8 text-center">
-        <ImageIcon className="text-subtle mb-3 h-8 w-8" />
-        <Text kind="body/regular/md" className="text-subtle">
-          Artifacts will appear here.
-        </Text>
-      </Flex>
-    )
-  }
-
-  return (
-    <Flex direction="col" gap="2" className="h-full overflow-y-auto">
-      {deepResearchFiles.map((file) => (
-        <div key={file.id} className="shrink-0">
-          <FileCard file={file} />
-        </div>
-      ))}
-    </Flex>
-  )
 }
 
 /**
@@ -190,6 +160,11 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
   const cancelFallbackRef = useRef<NodeJS.Timeout | null>(null)
   const loadKeyRef = useRef<string | null>(null)
 
+  const panelRef = useRef<HTMLDivElement>(null)
+  const resizeStartRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const [panelWidth, setPanelWidth] = useState<number | null>(null)
+  const [isResizing, setIsResizing] = useState(false)
+
   useEffect(() => {
     return () => {
       if (cancelFallbackRef.current) {
@@ -200,7 +175,11 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
   }, [])
 
   useEffect(() => {
-    if (!isAuthenticated || !isOpen || !deepResearchJobId || isStreamLoading) return
+    if (!isOpen) {
+      loadKeyRef.current = null
+      return
+    }
+    if (!isAuthenticated || !deepResearchJobId || isStreamLoading) return
     const key = `${rightPanel}:${deepResearchJobId}`
     if (loadKeyRef.current === key) return
     loadKeyRef.current = key
@@ -261,22 +240,131 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
   }, [deepResearchJobId, idToken])
 
   const isWide = WIDE_TABS.has(rightPanel)
-  const openWidth = isWide ? 'calc(60%)' : '420px'
   const panelLabel = getRailPanelLabel(rightPanel)
+  const minWidth = isWide ? WIDE_MIN_WIDTH : NARROW_MIN_WIDTH
+
+  useEffect(() => {
+    setPanelWidth((current) => (current == null ? current : clampPanelWidth(current, isWide)))
+  }, [isWide])
+
+  useEffect(() => {
+    const reclampToViewport = () => {
+      setPanelWidth((current) => (current == null ? current : clampPanelWidth(current, isWide)))
+    }
+    window.addEventListener('resize', reclampToViewport)
+    return () => window.removeEventListener('resize', reclampToViewport)
+  }, [isWide])
+
+  const measuredWidth = useCallback((): number => {
+    if (panelWidth != null) return panelWidth
+    const rect = panelRef.current?.getBoundingClientRect()
+    if (rect && rect.width > 0) return Math.round(rect.width)
+    return isWide ? FALLBACK_WIDE_WIDTH : NARROW_MIN_WIDTH
+  }, [panelWidth, isWide])
+
+  const applyWidth = useCallback(
+    (px: number) => {
+      setPanelWidth(clampPanelWidth(px, isWide))
+    },
+    [isWide]
+  )
+
+  const handleResizePointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return
+      resizeStartRef.current = { startX: e.clientX, startWidth: measuredWidth() }
+      e.currentTarget.setPointerCapture?.(e.pointerId)
+      setIsResizing(true)
+    },
+    [measuredWidth]
+  )
+
+  const handleResizePointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      const start = resizeStartRef.current
+      if (!start) return
+      applyWidth(start.startWidth + (start.startX - e.clientX))
+    },
+    [applyWidth]
+  )
+
+  const handleResizePointerUp = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!resizeStartRef.current) return
+    resizeStartRef.current = null
+    e.currentTarget.releasePointerCapture?.(e.pointerId)
+    setIsResizing(false)
+  }, [])
+
+  const handleResizeKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        applyWidth(measuredWidth() + KEYBOARD_STEP_PX)
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        applyWidth(measuredWidth() - KEYBOARD_STEP_PX)
+      }
+    },
+    [applyWidth, measuredWidth]
+  )
+
+  const maxWidth = getMaxWidth()
+  const currentPanelWidth = clampPanelWidth(panelWidth ?? measuredWidth(), isWide)
+
+  const openWidth =
+    panelWidth != null
+      ? `${clampPanelWidth(panelWidth, isWide)}px`
+      : isWide
+        ? `min(60%, ${MAX_WIDTH_PX}px, ${Math.round(MAX_WIDTH_VW_RATIO * 100)}vw)`
+        : `${NARROW_MIN_WIDTH}px`
 
   return (
     <div
+      ref={panelRef}
       data-testid="research-panel"
-      className={cn('border-base bg-surface-base h-full shrink-0 overflow-hidden', isOpen && 'border-l')}
+      className={cn(
+        'border-base bg-surface-base relative h-full shrink-0 overflow-hidden',
+        isOpen && 'border-l',
+        isResizing && 'select-none'
+      )}
       style={{
         width: isOpen ? openWidth : '0px',
-        minWidth: isOpen ? (isWide ? '480px' : '420px') : '0px',
-        transition: prefersReducedMotion
-          ? 'none'
-          : 'width 400ms ease-in-out, min-width 400ms ease-in-out',
+        minWidth: isOpen ? `${minWidth}px` : '0px',
+        transition:
+          prefersReducedMotion || isResizing
+            ? 'none'
+            : 'width 400ms ease-in-out, min-width 400ms ease-in-out',
       }}
       aria-hidden={!isOpen}
     >
+      {isOpen && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize panel"
+          aria-valuenow={currentPanelWidth}
+          aria-valuemin={Math.min(minWidth, maxWidth)}
+          aria-valuemax={maxWidth}
+          tabIndex={0}
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={handleResizePointerUp}
+          onPointerCancel={handleResizePointerUp}
+          onKeyDown={handleResizeKeyDown}
+          data-testid="research-panel-resize"
+          className="group focus-visible:ring-brand absolute left-0 top-0 z-10 flex h-full w-3 cursor-col-resize touch-none select-none items-center justify-center outline-none focus-visible:ring-2 focus-visible:ring-inset"
+        >
+          <span
+            aria-hidden="true"
+            className="text-subtle group-hover:text-secondary flex flex-col items-center justify-center gap-1 transition-colors"
+          >
+            <span className="h-1 w-1 rounded-full bg-current" />
+            <span className="h-1 w-1 rounded-full bg-current" />
+            <span className="h-1 w-1 rounded-full bg-current" />
+            <span className="h-1 w-1 rounded-full bg-current" />
+          </span>
+        </div>
+      )}
       <Flex
         direction="col"
         className="h-full w-full"
@@ -301,17 +389,24 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
           </Text>
           <Flex align="center" gap="2">
             {isDeepResearchStreaming && (
-              <Button
-                kind="tertiary"
-                size="small"
-                onClick={handleStopResearch}
-                aria-label="Stop researching"
-                title="Stop researching"
-                data-testid="research-panel-stop"
-              >
-                <StopCircle className="mr-2 h-4 w-4" aria-hidden="true" />
-                Stop Researching
-              </Button>
+              <>
+                <Button
+                  kind="tertiary"
+                  size="small"
+                  onClick={handleStopResearch}
+                  aria-label="Stop researching"
+                  title="Stop researching"
+                  data-testid="research-panel-stop"
+                >
+                  <StopCircle className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Stop Researching
+                </Button>
+                <span
+                  aria-hidden="true"
+                  data-testid="research-panel-header-divider"
+                  className="border-base ml-1 h-5 border-l"
+                />
+              </>
             )}
             <Button
               kind="tertiary"
@@ -340,9 +435,7 @@ export const ResearchPanel: FC<ResearchPanelProps> = memo(function ResearchPanel
           ) : rightPanel === 'thinking' ? (
             <ThinkingView />
           ) : rightPanel === 'citations' ? (
-            <CitationsView />
-          ) : rightPanel === 'artifacts' ? (
-            <ArtifactsView />
+            <ResearchSourcesView />
           ) : null}
         </Flex>
       </Flex>

--- a/frontends/ui/src/features/layout/components/ResearchSourcesView.spec.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchSourcesView.spec.tsx
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen, within } from '@/test-utils'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+import { ResearchSourcesView } from './ResearchSourcesView'
+
+interface MockCitation {
+  id: string
+  url: string
+  content: string
+  timestamp: Date
+  isCited?: boolean
+}
+
+interface MockState {
+  reportContent?: string
+  deepResearchCitations: MockCitation[]
+}
+
+const defaultState: MockState = {
+  reportContent: '',
+  deepResearchCitations: [],
+}
+
+let mockState: MockState = { ...defaultState }
+
+vi.mock('@/features/chat', () => ({
+  useChatStore: vi.fn((selector?: (state: MockState) => unknown) => {
+    return selector ? selector(mockState) : mockState
+  }),
+}))
+
+const citedAndRead: MockCitation[] = [
+  {
+    id: 'read-source',
+    url: 'https://read.example',
+    content: 'Source read during research',
+    timestamp: new Date('2026-05-01T00:00:00Z'),
+    isCited: false,
+  },
+  {
+    id: 'cited-source',
+    url: 'https://cited.example',
+    content: 'Source cited in final report',
+    timestamp: new Date('2026-05-02T00:00:00Z'),
+    isCited: true,
+  },
+]
+
+describe('ResearchSourcesView', () => {
+  beforeEach(() => {
+    mockState = { ...defaultState }
+  })
+
+  test('shows an empty state when there are no sources', () => {
+    render(<ResearchSourcesView />)
+
+    expect(screen.getByText('Sources the agent reads will appear here.')).toBeInTheDocument()
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+  })
+
+  test('renders the All / Cited filter over the merged list', () => {
+    mockState = { ...defaultState, deepResearchCitations: citedAndRead }
+    render(<ResearchSourcesView />)
+
+    expect(screen.getAllByRole('radio').map((radio) => radio.textContent)).toEqual([
+      'All',
+      'Cited (1)',
+    ])
+  })
+
+  test('shows both cited and uncited sources grouped in All mode', () => {
+    mockState = { ...defaultState, deepResearchCitations: citedAndRead }
+    render(<ResearchSourcesView />)
+
+    expect(screen.getByText('Cited in report')).toBeInTheDocument()
+    expect(screen.getByText('Other sources found')).toBeInTheDocument()
+    expect(screen.getByText('cited.example')).toBeInTheDocument()
+    expect(screen.getByText('read.example')).toBeInTheDocument()
+  })
+
+  test('filters to only cited sources on demand', async () => {
+    const user = userEvent.setup()
+    mockState = { ...defaultState, deepResearchCitations: citedAndRead }
+    render(<ResearchSourcesView />)
+
+    await user.click(screen.getByRole('radio', { name: /Cited \(1\)/i }))
+
+    expect(screen.getByText('cited.example')).toBeInTheDocument()
+    expect(screen.queryByText('read.example')).not.toBeInTheDocument()
+    expect(screen.queryByText('Other sources found')).not.toBeInTheDocument()
+  })
+
+  test('shows a cited-specific empty state when nothing was cited', async () => {
+    const user = userEvent.setup()
+    mockState = {
+      ...defaultState,
+      deepResearchCitations: [citedAndRead[0]],
+    }
+    render(<ResearchSourcesView />)
+
+    await user.click(screen.getByRole('radio', { name: /Cited \(0\)/i }))
+
+    expect(screen.getByText('No sources were cited in the report.')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Sources the agent reads will appear here.')
+    ).not.toBeInTheDocument()
+  })
+
+  test('cited sources and their numbers come from the report [N], not discovery order', () => {
+    mockState = {
+      reportContent:
+        'Body [1] and [2].\n\n## Sources\n[1] Report first: https://cited-b.example\n[2] Report second: https://cited-a.example',
+      deepResearchCitations: [
+        {
+          id: 'a',
+          url: 'https://cited-a.example',
+          content: '',
+          timestamp: new Date('2026-05-01T00:00:00Z'),
+          isCited: true,
+        },
+        {
+          id: 'b',
+          url: 'https://cited-b.example',
+          content: '',
+          timestamp: new Date('2026-05-02T00:00:00Z'),
+          isCited: true,
+        },
+        {
+          id: 'read',
+          url: 'https://read.example',
+          content: '',
+          timestamp: new Date('2026-05-03T00:00:00Z'),
+          isCited: false,
+        },
+      ],
+    }
+    render(<ResearchSourcesView />)
+
+    const citedRegion = screen.getByRole('region', { name: 'Cited in report' })
+    const rows = within(citedRegion).getAllByRole('listitem')
+    expect(rows).toHaveLength(2)
+    expect(within(rows[0]).getByText('1')).toBeInTheDocument()
+    expect(within(rows[0]).getByText('cited-b.example')).toBeInTheDocument()
+    expect(within(rows[1]).getByText('2')).toBeInTheDocument()
+    expect(within(rows[1]).getByText('cited-a.example')).toBeInTheDocument()
+
+    const otherRegion = screen.getByRole('region', { name: 'Other sources found' })
+    expect(within(otherRegion).getByText('read.example')).toBeInTheDocument()
+    expect(within(otherRegion).queryByText('cited-a.example')).not.toBeInTheDocument()
+    expect(within(otherRegion).queryByText('cited-b.example')).not.toBeInTheDocument()
+  })
+
+  test('numbers uncited sources after the highest report [N], even with gaps', () => {
+    mockState = {
+      reportContent:
+        'Body [1] and [5].\n\n## Sources\n[1] Report first: https://cited-a.example\n[5] Report fifth: https://cited-b.example',
+      deepResearchCitations: [
+        {
+          id: 'read',
+          url: 'https://read.example',
+          content: '',
+          timestamp: new Date('2026-05-03T00:00:00Z'),
+          isCited: false,
+        },
+      ],
+    }
+    render(<ResearchSourcesView />)
+
+    const citedRegion = screen.getByRole('region', { name: 'Cited in report' })
+    expect(within(citedRegion).getByText('1')).toBeInTheDocument()
+    expect(within(citedRegion).getByText('5')).toBeInTheDocument()
+
+    const otherRegion = screen.getByRole('region', { name: 'Other sources found' })
+    const otherRows = within(otherRegion).getAllByRole('listitem')
+    expect(otherRows).toHaveLength(1)
+    expect(within(otherRows[0]).getByText('6')).toBeInTheDocument()
+    expect(within(otherRows[0]).getByText('read.example')).toBeInTheDocument()
+    expect(within(otherRegion).queryByText('1')).not.toBeInTheDocument()
+    expect(within(otherRegion).queryByText('5')).not.toBeInTheDocument()
+  })
+
+  test('treats a citation that differs only by a trailing slash as cited', () => {
+    mockState = {
+      reportContent: 'Body [1].\n\n## Sources\n[1] Report page: https://example.com/page',
+      deepResearchCitations: [
+        {
+          id: 'dup',
+          url: 'https://example.com/page/',
+          content: '',
+          timestamp: new Date('2026-05-01T00:00:00Z'),
+          isCited: false,
+        },
+      ],
+    }
+    render(<ResearchSourcesView />)
+
+    const citedRegion = screen.getByRole('region', { name: 'Cited in report' })
+    expect(within(citedRegion).getByText('example.com')).toBeInTheDocument()
+
+    expect(screen.queryByText('Other sources found')).not.toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /Cited \(1\)/i })).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(1)
+  })
+
+  test('does not re-list a url-less cited document under Other sources found', () => {
+    mockState = {
+      reportContent: 'Body [1].\n\n## Sources\n[1] q3_report.pdf, p.4',
+      deepResearchCitations: [
+        {
+          id: 'file-cite',
+          url: '',
+          content: 'q3_report.pdf, p.4',
+          timestamp: new Date('2026-05-01T00:00:00Z'),
+          isCited: true,
+        },
+      ],
+    }
+    render(<ResearchSourcesView />)
+
+    const citedRegion = screen.getByRole('region', { name: 'Cited in report' })
+    expect(within(citedRegion).getByText('q3_report.pdf, p.4')).toBeInTheDocument()
+
+    expect(screen.queryByText('Other sources found')).not.toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /Cited \(1\)/i })).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(1)
+  })
+})

--- a/frontends/ui/src/features/layout/components/ResearchSourcesView.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchSourcesView.tsx
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ResearchSourcesView Component
+ *
+ * The single, consolidated home for every source the deep-research agent
+ * touched, rendered by the Citations rail panel. Cited sources come from the
+ * finished report's own reference block via the authoritative
+ * {@link splitReferences} metadata that ReportTab uses, so their numbers match
+ * the report's inline [N]. Sources the agent read but the report did not cite
+ * are listed under "Other sources found". When the report has no parseable
+ * references (for example an interrupted run), it falls back to the stream
+ * citations split by their cited flag. An All / Cited filter toggles between the
+ * groups; rows use the compact single-line SourceList styling.
+ */
+
+'use client'
+
+import { type FC, useCallback, useMemo, useState } from 'react'
+import { Flex, SegmentedControl, Text } from '@/adapters/ui'
+import { Book } from '@/adapters/ui/icons'
+import { useChatStore } from '@/features/chat'
+import { SourceList } from '@/shared/components/Sources/SourceList'
+import { mapCitationSource } from '@/shared/components/Sources/source-utils'
+import { splitReferences } from '@/shared/components/Sources/parse-references'
+import type { SourceRef } from '@/shared/components/Sources/types'
+import { EMPTY_RESEARCH_DETAILS_HELP_TEXT } from './research-empty-state-copy'
+
+/** Source-list filter: every source, or only those cited in the report. */
+type SourceFilter = 'all' | 'cited'
+
+/**
+ * Normalize a URL for cited/uncited comparison: lowercase host, drop a leading
+ * `www.`, strip the fragment, and remove a trailing slash. Falls back to a
+ * lightweight string normalize when the value is not a parseable URL.
+ */
+function normalizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    const host = parsed.host.toLowerCase().replace(/^www\./, '')
+    const path = parsed.pathname.replace(/\/$/, '')
+    return `${parsed.protocol}${host}${path}${parsed.search}`
+  } catch {
+    return url.trim().toLowerCase().replace(/#.*$/, '').replace(/\/$/, '')
+  }
+}
+
+export const ResearchSourcesView: FC = () => {
+  const reportContent = useChatStore((s) => s.reportContent)
+  const deepResearchCitations = useChatStore((s) => s.deepResearchCitations)
+  const [filter, setFilter] = useState<SourceFilter>('all')
+
+  const { cited, other, total } = useMemo(() => {
+    const reportStr = typeof reportContent === 'string' ? reportContent : ''
+    const reportSources = splitReferences(reportStr).sources
+    const citations = deepResearchCitations ?? []
+
+    if (reportSources.length > 0) {
+      const citedUrls = new Set(
+        reportSources
+          .map((source) => source.url)
+          .filter((url): url is string => Boolean(url))
+          .map(normalizeUrl)
+      )
+      const lastReportIndex = reportSources.reduce((max, s) => Math.max(max, s.index), 0)
+      const otherSources: SourceRef[] = citations
+        .filter((citation) => citation.url && !citedUrls.has(normalizeUrl(citation.url)))
+        .map((citation, index) => mapCitationSource(citation, lastReportIndex + index))
+      return {
+        cited: reportSources,
+        other: otherSources,
+        total: reportSources.length + otherSources.length,
+      }
+    }
+
+    const mapped = citations.map((citation, index) => ({
+      source: mapCitationSource(citation, index),
+      isCited: Boolean(citation.isCited),
+    }))
+    return {
+      cited: mapped.filter((entry) => entry.isCited).map((entry) => entry.source),
+      other: mapped.filter((entry) => !entry.isCited).map((entry) => entry.source),
+      total: mapped.length,
+    }
+  }, [reportContent, deepResearchCitations])
+
+  const handleFilterChange = useCallback((value: string) => {
+    setFilter(value as SourceFilter)
+  }, [])
+
+  return (
+    <Flex direction="col" gap="4" className="h-full min-h-0">
+      <Flex direction="col" gap="2" className="shrink-0">
+        <Flex align="center" gap="2">
+          <Text kind="label/semibold/md" className="text-primary">
+            Sources
+          </Text>
+          {total > 0 && (
+            <Text kind="body/regular/xs" className="text-secondary tabular-nums">
+              {total}
+            </Text>
+          )}
+        </Flex>
+        {total > 0 && (
+          <div>
+            <SegmentedControl
+              value={filter}
+              onValueChange={handleFilterChange}
+              size="small"
+              items={[
+                { value: 'all', children: 'All' },
+                { value: 'cited', children: `Cited (${cited.length})` },
+              ]}
+            />
+          </div>
+        )}
+      </Flex>
+
+      {total === 0 ? (
+        <Flex direction="col" align="center" justify="center" className="flex-1 py-8 text-center">
+          <Book className="text-secondary mb-3 h-8 w-8" />
+          <Text kind="body/regular/md" className="text-secondary">
+            Sources the agent reads will appear here.
+          </Text>
+          <Text kind="body/regular/sm" className="text-secondary mt-2">
+            {EMPTY_RESEARCH_DETAILS_HELP_TEXT}
+          </Text>
+        </Flex>
+      ) : filter === 'cited' && cited.length === 0 ? (
+        <Flex direction="col" align="center" justify="center" className="flex-1 py-8 text-center">
+          <Book className="text-secondary mb-3 h-8 w-8" />
+          <Text kind="body/regular/md" className="text-secondary">
+            No sources were cited in the report.
+          </Text>
+          <Text kind="body/regular/sm" className="text-secondary mt-2">
+            Switch to All to see every source the agent found.
+          </Text>
+        </Flex>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {filter === 'cited' ? (
+            <SourceList sources={cited} title="Cited in report" />
+          ) : (
+            <>
+              <SourceList sources={cited} title="Cited in report" />
+              <SourceList sources={other} title="Other sources found" />
+            </>
+          )}
+        </div>
+      )}
+    </Flex>
+  )
+}

--- a/frontends/ui/src/features/layout/components/SessionsPanel.spec.tsx
+++ b/frontends/ui/src/features/layout/components/SessionsPanel.spec.tsx
@@ -288,7 +288,7 @@ describe('SessionsPanel', () => {
     render(<SessionsPanel sessions={mockSessions} />)
 
     expect(screen.getByRole('button', { name: /expand sessions sidebar/i })).toBeInTheDocument()
-    expect(screen.queryByText('Sessions')).not.toBeInTheDocument()
+    expect(screen.getByText('Sessions')).toHaveClass('opacity-0')
     expect(screen.queryByText('First Session')).not.toBeInTheDocument()
   })
 

--- a/frontends/ui/src/features/layout/components/SessionsPanel.tsx
+++ b/frontends/ui/src/features/layout/components/SessionsPanel.tsx
@@ -98,17 +98,20 @@ const NavRow: FC<{
     aria-label={ariaLabel ?? label}
     title={title ?? label}
     className={cn(
-      'flex h-10 w-full items-center rounded-lg transition-colors',
-      collapsed ? 'justify-center px-0' : 'gap-3 px-3',
+      'flex h-10 w-full items-center gap-3 rounded-lg px-2.5 transition-colors',
       disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-surface-raised-50 cursor-pointer'
     )}
   >
     <span className="text-secondary grid h-5 w-5 shrink-0 place-items-center">{icon}</span>
-    {!collapsed && (
-      <Text kind="label/regular/sm" className="text-primary truncate">
-        {label}
-      </Text>
-    )}
+    <Text
+      kind="label/regular/sm"
+      className={cn(
+        'text-primary min-w-0 truncate text-left transition-opacity duration-300 motion-reduce:transition-none',
+        collapsed ? 'pointer-events-none opacity-0' : 'opacity-100'
+      )}
+    >
+      {label}
+    </Text>
   </button>
 )
 
@@ -244,35 +247,27 @@ export const SessionsPanel: FC<SessionsPanelProps> = memo(function SessionsPanel
       aria-label="Sessions"
     >
       <Flex direction="col" className="h-full gap-1 p-2">
-        {/* Header row: title + collapse toggle (or a single expand button when collapsed) */}
-        {collapsed ? (
-          <Flex align="center" justify="center" className="h-10">
-            <button
-              type="button"
-              onClick={toggleSidebar}
-              aria-label="Expand sessions sidebar"
-              title="Expand sessions"
-              className="hover:bg-surface-raised-50 grid h-10 w-10 cursor-pointer place-items-center rounded-lg"
-            >
-              <Menu className="text-secondary h-5 w-5" />
-            </button>
-          </Flex>
-        ) : (
-          <Flex align="center" gap="3" className="h-10 px-3">
-            <button
-              type="button"
-              onClick={toggleSidebar}
-              aria-label="Collapse sessions sidebar"
-              title="Collapse sessions"
-              className="hover:bg-surface-raised-50 grid h-8 w-8 shrink-0 cursor-pointer place-items-center rounded-md"
-            >
-              <Menu className="text-secondary h-5 w-5" />
-            </button>
-            <Text kind="label/semibold/md" className="text-primary flex-1 truncate">
-              Sessions
-            </Text>
-          </Flex>
-        )}
+        {/* Header row: collapse toggle whose icon stays anchored while the title fades */}
+        <button
+          type="button"
+          onClick={toggleSidebar}
+          aria-label={collapsed ? 'Expand sessions sidebar' : 'Collapse sessions sidebar'}
+          title={collapsed ? 'Expand sessions' : 'Collapse sessions'}
+          className="hover:bg-surface-raised-50 flex h-10 w-full cursor-pointer items-center gap-3 rounded-lg px-2.5 transition-colors"
+        >
+          <span className="text-secondary grid h-5 w-5 shrink-0 place-items-center">
+            <Menu className="h-5 w-5" />
+          </span>
+          <Text
+            kind="label/semibold/md"
+            className={cn(
+              'text-primary min-w-0 flex-1 truncate text-left transition-opacity duration-300 motion-reduce:transition-none',
+              collapsed ? 'pointer-events-none opacity-0' : 'opacity-100'
+            )}
+          >
+            Sessions
+          </Text>
+        </button>
 
         <NavRow
           icon={<Plus className="h-5 w-5" />}
@@ -294,7 +289,7 @@ export const SessionsPanel: FC<SessionsPanelProps> = memo(function SessionsPanel
 
         {hasSessions &&
           (!collapsed && searchOpen ? (
-            <Flex align="center" gap="3" className="h-10 px-3">
+            <Flex align="center" gap="3" className="h-10 px-2.5">
               <span className="text-secondary grid h-5 w-5 shrink-0 place-items-center">
                 <Search className="h-5 w-5" />
               </span>

--- a/frontends/ui/src/features/layout/components/ThinkingTab.spec.tsx
+++ b/frontends/ui/src/features/layout/components/ThinkingTab.spec.tsx
@@ -12,21 +12,11 @@ interface MockFile {
   content: string
 }
 
-interface MockCitation {
-  id: string
-  url: string
-  content: string
-  timestamp: Date
-  isCited?: boolean
-}
-
 interface MockState {
-  deepResearchCitations: MockCitation[]
   deepResearchFiles: MockFile[]
 }
 
 const defaultState: MockState = {
-  deepResearchCitations: [],
   deepResearchFiles: [],
 }
 
@@ -48,114 +38,29 @@ vi.mock('./FileCard', () => ({
   ),
 }))
 
-vi.mock('./CitationCard', () => ({
-  CitationCard: ({ citation }: { citation: MockCitation }) => (
-    <article data-testid="citation-card">{citation.url}</article>
-  ),
-}))
-
 describe('ThinkingTab', () => {
   beforeEach(() => {
     mockState = { ...defaultState }
   })
 
-  test('collapses to exactly two sub-tabs: Steps and Sources', () => {
-    render(<ThinkingTab />)
-
-    expect(screen.getAllByRole('radio').map((radio) => radio.textContent)).toEqual([
-      'Steps',
-      'Sources',
-    ])
-  })
-
-  test('shows the Steps view by default', () => {
+  test('renders the steps trace directly', () => {
     render(<ThinkingTab />)
 
     expect(screen.getByTestId('agents-tab')).toBeInTheDocument()
   })
 
-  test('switches to Sources on demand', async () => {
-    const user = userEvent.setup()
+  test('no longer renders a Steps/Sources sub-tab bar', () => {
     render(<ThinkingTab />)
 
-    await user.click(screen.getByRole('radio', { name: /Sources/i }))
-
-    expect(screen.getByText('Sources the agent reads will appear here.')).toBeInTheDocument()
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: /Sources/i })).not.toBeInTheDocument()
   })
 
-  test('merges read + cited into one list with All / Cited filter', async () => {
-    const user = userEvent.setup()
-    mockState = {
-      ...defaultState,
-      deepResearchCitations: [
-        {
-          id: 'read-source',
-          url: 'https://read.example',
-          content: 'Source read during research',
-          timestamp: new Date('2026-05-01T00:00:00Z'),
-          isCited: false,
-        },
-        {
-          id: 'cited-source',
-          url: 'https://cited.example',
-          content: 'Source cited in final report',
-          timestamp: new Date('2026-05-02T00:00:00Z'),
-          isCited: true,
-        },
-      ],
-    }
-
-    render(<ThinkingTab />)
-    await user.click(screen.getByRole('radio', { name: /Sources/i }))
-
-    expect(screen.getByText('Cited in report')).toBeInTheDocument()
-    expect(screen.getByText('Other sources found')).toBeInTheDocument()
-    expect(screen.getByText('https://read.example')).toBeInTheDocument()
-    expect(screen.getByText('https://cited.example')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('radio', { name: /Cited \(1\)/i }))
-
-    expect(screen.getByText('https://cited.example')).toBeInTheDocument()
-    expect(screen.queryByText('https://read.example')).not.toBeInTheDocument()
-  })
-
-  test('shows a cited-specific empty state when sources exist but none are cited', async () => {
-    const user = userEvent.setup()
-    mockState = {
-      ...defaultState,
-      deepResearchCitations: [
-        {
-          id: 'read-only',
-          url: 'https://read.example',
-          content: 'Source read but not cited',
-          timestamp: new Date('2026-05-01T00:00:00Z'),
-          isCited: false,
-        },
-      ],
-    }
-
-    render(<ThinkingTab />)
-    await user.click(screen.getByRole('radio', { name: /Sources/i }))
-    await user.click(screen.getByRole('radio', { name: /Cited \(0\)/i }))
-
-    expect(screen.getByText('No sources were cited in the report.')).toBeInTheDocument()
-    expect(
-      screen.queryByText('Sources the agent reads will appear here.')
-    ).not.toBeInTheDocument()
-  })
-
-  test('shows clear empty-state copy for Sources', async () => {
-    const user = userEvent.setup()
+  test('does not render any source list (sources live in the Citations panel)', () => {
     render(<ThinkingTab />)
 
-    await user.click(screen.getByRole('radio', { name: /Sources/i }))
-
-    expect(screen.getByText('Sources the agent reads will appear here.')).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'These details appear during active research and may not be available for completed reports.'
-      )
-    ).toBeInTheDocument()
+    expect(screen.queryByText('Cited in report')).not.toBeInTheDocument()
+    expect(screen.queryByText('Other sources found')).not.toBeInTheDocument()
   })
 
   test('folds generated files into a thin disclosure only when files exist', async () => {

--- a/frontends/ui/src/features/layout/components/ThinkingTab.tsx
+++ b/frontends/ui/src/features/layout/components/ThinkingTab.tsx
@@ -4,240 +4,66 @@
 /**
  * ThinkingTab Component
  *
- * The "Thinking" tab of the research panel, reduced to two clear sub-tabs:
- *
- * - STEPS: the single authoritative view of what the agent did. Tool calls are
- *   grouped under their parent agent (human label + status + count). Raw model
- *   reasoning is demoted to a collapsed disclosure inside that view. A thin
- *   "Generated files" section appears only when files exist.
- * - SOURCES: one merged list of every source the agent touched, with a small
- *   All / Cited filter ("Cited in report" vs "Other sources found").
+ * The "Thinking" panel: the single authoritative reasoning/steps trace of what
+ * the agent did. Tool calls are grouped under their parent agent (human label +
+ * status + count) and raw model reasoning is demoted to a collapsed disclosure
+ * inside that view. A thin "Generated files" disclosure appears only when files
+ * exist. Sources now live entirely in the Citations panel (ResearchSourcesView).
  *
  * SSE Events (Deep Research only):
  * - workflow.start/end, tool.start/end, llm.start/end → Steps
- * - artifact.update (file) → Steps (Generated files section)
- * - artifact.update (citation_source/citation_use) → Sources
+ * - artifact.update (file) → Generated files disclosure
  */
 
 'use client'
 
-import { type FC, useState, useCallback, useMemo } from 'react'
-import { Flex, SegmentedControl, Text } from '@/adapters/ui'
-import { Book, Document, ChevronDown } from '@/adapters/ui/icons'
+import { type FC, useState } from 'react'
+import { Flex, Text } from '@/adapters/ui'
+import { Document, ChevronDown } from '@/adapters/ui/icons'
 import { useChatStore } from '@/features/chat'
-import { useShallow } from 'zustand/react/shallow'
 import { AgentsTab } from './AgentsTab'
 import { FileCard } from './FileCard'
-import { CitationCard } from './CitationCard'
-import { EMPTY_RESEARCH_DETAILS_HELP_TEXT } from './research-empty-state-copy'
-import type { CitationSource } from '@/features/chat/types'
-
-/** Top-level sub-tabs within Thinking. */
-type ThinkingSubTab = 'steps' | 'sources'
-
-/** Source-list filter: every source, or only those cited in the report. */
-type SourceFilter = 'all' | 'cited'
-
-interface SourcesViewProps {
-  citations: CitationSource[]
-}
 
 /**
- * One merged source list (replaces the old "Read" + "Referenced" sub-tabs) with
- * an All / Cited filter. Cited sources are labelled "Cited in report" and the
- * rest "Other sources found".
+ * Thinking panel content: the steps trace plus a thin generated-files
+ * disclosure. Consumes the dedicated files array from the chat store.
  */
-const SourcesView: FC<SourcesViewProps> = ({ citations }) => {
-  const [filter, setFilter] = useState<SourceFilter>('all')
-
-  const sorted = useMemo(
-    () =>
-      [...citations].sort(
-        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-      ),
-    [citations]
-  )
-
-  const cited = useMemo(() => sorted.filter((c) => c.isCited), [sorted])
-  const other = useMemo(() => sorted.filter((c) => !c.isCited), [sorted])
-  const shown = filter === 'cited' ? cited : sorted
-
-  const handleFilterChange = useCallback((value: string) => {
-    setFilter(value as SourceFilter)
-  }, [])
+export const ThinkingTab: FC = () => {
+  const deepResearchFiles = useChatStore((s) => s.deepResearchFiles)
+  const [showFiles, setShowFiles] = useState(false)
 
   return (
-    <Flex direction="col" gap="4" className="h-full min-h-0">
-      <Flex direction="col" gap="2" className="shrink-0">
-        <Flex align="center" gap="2">
-          <Text kind="label/semibold/md" className="text-primary">
-            Sources
-          </Text>
-          {sorted.length > 0 && (
-            <Text kind="body/regular/xs" className="text-secondary tabular-nums">
-              {sorted.length}
-            </Text>
-          )}
-        </Flex>
-        {sorted.length > 0 && (
-          <div>
-            <SegmentedControl
-              value={filter}
-              onValueChange={handleFilterChange}
-              size="small"
-              items={[
-                { value: 'all', children: 'All' },
-                { value: 'cited', children: `Cited (${cited.length})` },
-              ]}
-            />
-          </div>
-        )}
-      </Flex>
+    <Flex direction="col" gap="3" className="h-full min-h-0">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <AgentsTab />
+      </div>
 
-      {shown.length === 0 ? (
-        filter === 'cited' && sorted.length > 0 ? (
-          <Flex direction="col" align="center" justify="center" className="flex-1 py-8 text-center">
-            <Book className="text-secondary mb-3 h-8 w-8" />
-            <Text kind="body/regular/md" className="text-secondary">
-              No sources were cited in the report.
-            </Text>
-            <Text kind="body/regular/sm" className="text-secondary mt-2">
-              Switch to All to see every source the agent found.
-            </Text>
-          </Flex>
-        ) : (
-          <Flex direction="col" align="center" justify="center" className="flex-1 py-8 text-center">
-            <Book className="text-secondary mb-3 h-8 w-8" />
-            <Text kind="body/regular/md" className="text-secondary">
-              Sources the agent reads will appear here.
-            </Text>
-            <Text kind="body/regular/sm" className="text-secondary mt-2">
-              {EMPTY_RESEARCH_DETAILS_HELP_TEXT}
-            </Text>
-          </Flex>
-        )
-      ) : (
-        <Flex direction="col" gap="3" className="min-h-0 flex-1 overflow-y-auto">
-          {filter === 'all' ? (
-            <>
-              {cited.length > 0 && (
-                <Flex direction="col" gap="2">
-                  <Text kind="label/semibold/sm" className="text-secondary">
-                    Cited in report
-                  </Text>
-                  {cited.map((citation) => (
-                    <div key={citation.id} className="shrink-0">
-                      <CitationCard citation={citation} />
-                    </div>
-                  ))}
-                </Flex>
-              )}
-              {other.length > 0 && (
-                <Flex direction="col" gap="2">
-                  <Text kind="label/semibold/sm" className="text-secondary">
-                    Other sources found
-                  </Text>
-                  {other.map((citation) => (
-                    <div key={citation.id} className="shrink-0">
-                      <CitationCard citation={citation} />
-                    </div>
-                  ))}
-                </Flex>
-              )}
-            </>
-          ) : (
-            shown.map((citation) => (
-              <div key={citation.id} className="shrink-0">
-                <CitationCard citation={citation} />
-              </div>
-            ))
+      {deepResearchFiles.length > 0 && (
+        <Flex direction="col" gap="2" className="border-base shrink-0 border-t pt-3">
+          <button
+            type="button"
+            onClick={() => setShowFiles((v) => !v)}
+            aria-expanded={showFiles}
+            className="text-secondary hover:text-primary flex cursor-pointer items-center gap-1.5 self-start transition-colors"
+          >
+            <Document className="h-4 w-4" aria-hidden="true" />
+            <Text kind="body/regular/sm">Generated files ({deepResearchFiles.length})</Text>
+            <ChevronDown
+              className={`h-4 w-4 transition-transform duration-200 ${showFiles ? 'rotate-180' : ''}`}
+              aria-hidden="true"
+            />
+          </button>
+          {showFiles && (
+            <Flex direction="col" gap="2" className="max-h-64 overflow-y-auto">
+              {deepResearchFiles.map((file) => (
+                <div key={file.id} className="shrink-0">
+                  <FileCard file={file} />
+                </div>
+              ))}
+            </Flex>
           )}
         </Flex>
       )}
-    </Flex>
-  )
-}
-
-/**
- * Thinking tab content, reduced to Steps + Sources. Consumes dedicated state
- * arrays from the chat store.
- */
-export const ThinkingTab: FC = () => {
-  const { deepResearchCitations, deepResearchFiles } = useChatStore(
-    useShallow((s) => ({
-      deepResearchCitations: s.deepResearchCitations,
-      deepResearchFiles: s.deepResearchFiles,
-    }))
-  )
-
-  const [activeSubTab, setActiveSubTab] = useState<ThinkingSubTab>('steps')
-  const [showFiles, setShowFiles] = useState(false)
-
-  const handleSubTabChange = useCallback((value: string) => {
-    setActiveSubTab(value as ThinkingSubTab)
-  }, [])
-
-  return (
-    <Flex direction="col" gap="4" className="h-full min-h-0">
-      {}
-      <div className="shrink-0">
-        <SegmentedControl
-          value={activeSubTab}
-          onValueChange={handleSubTabChange}
-          size="small"
-          items={[
-            { value: 'steps', children: 'Steps' },
-            { value: 'sources', children: 'Sources' },
-          ]}
-        />
-      </div>
-
-      {}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {activeSubTab === 'steps' && (
-          <Flex direction="col" gap="3" className="h-full min-h-0">
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              <AgentsTab />
-            </div>
-
-            {}
-            {deepResearchFiles.length > 0 && (
-              <Flex direction="col" gap="2" className="border-base shrink-0 border-t pt-3">
-                <button
-                  type="button"
-                  onClick={() => setShowFiles((v) => !v)}
-                  aria-expanded={showFiles}
-                  className="text-secondary hover:text-primary flex items-center gap-1.5 self-start transition-colors"
-                >
-                  <Document className="h-4 w-4" aria-hidden="true" />
-                  <Text kind="body/regular/sm">
-                    Generated files ({deepResearchFiles.length})
-                  </Text>
-                  <ChevronDown
-                    className={`h-4 w-4 transition-transform duration-200 ${showFiles ? 'rotate-180' : ''}`}
-                    aria-hidden="true"
-                  />
-                </button>
-                {showFiles && (
-                  <Flex direction="col" gap="2" className="max-h-64 overflow-y-auto">
-                    {deepResearchFiles.map((file) => (
-                      <div key={file.id} className="shrink-0">
-                        <FileCard file={file} />
-                      </div>
-                    ))}
-                  </Flex>
-                )}
-              </Flex>
-            )}
-          </Flex>
-        )}
-
-        {activeSubTab === 'sources' && (
-          <div className="min-h-0 flex-1 overflow-hidden">
-            <SourcesView citations={deepResearchCitations} />
-          </div>
-        )}
-      </div>
     </Flex>
   )
 }

--- a/frontends/ui/src/features/layout/components/index.ts
+++ b/frontends/ui/src/features/layout/components/index.ts
@@ -8,6 +8,7 @@
 // Main layout components
 export { MainLayout } from './MainLayout'
 export { AppBar } from './AppBar'
+export { DeepResearchRail } from './DeepResearchRail'
 export { SessionsPanel } from './SessionsPanel'
 export { ChatArea } from './ChatArea'
 export { InputArea } from './InputArea'

--- a/frontends/ui/src/features/layout/index.ts
+++ b/frontends/ui/src/features/layout/index.ts
@@ -11,6 +11,7 @@
 export {
   MainLayout,
   AppBar,
+  DeepResearchRail,
   SessionsPanel,
   ChatArea,
   InputArea,

--- a/frontends/ui/src/features/layout/store.spec.ts
+++ b/frontends/ui/src/features/layout/store.spec.ts
@@ -109,6 +109,15 @@ describe('useLayoutStore', () => {
       expect(useLayoutStore.getState().rightPanel).toBe('settings')
     })
 
+    test.each(['citations', 'thinking'] as const)(
+      'opens the %s rail panel',
+      (panel) => {
+        useLayoutStore.getState().openRightPanel(panel)
+
+        expect(useLayoutStore.getState().rightPanel).toBe(panel)
+      }
+    )
+
     test('replaces existing panel', () => {
       useLayoutStore.setState({ rightPanel: 'research' })
 
@@ -163,6 +172,27 @@ describe('useLayoutStore', () => {
       expect(useLayoutStore.getState().rightPanel).toBe('research')
       expect(useLayoutStore.getState().sessionsCollapsed).toBe(true)
       expect(useLayoutStore.getState().sessionsAutoCollapsed).toBe(true)
+    })
+
+    test.each(['data-sources', 'citations', 'research', 'thinking'] as const)(
+      'opening the %s rail panel auto-collapses the sidebar',
+      (panel) => {
+        useLayoutStore.setState({ sessionsCollapsed: false, rightPanel: null })
+
+        useLayoutStore.getState().openRightPanel(panel)
+
+        expect(useLayoutStore.getState().sessionsCollapsed).toBe(true)
+        expect(useLayoutStore.getState().sessionsAutoCollapsed).toBe(true)
+      }
+    )
+
+    test('opening the settings overlay does not collapse the sidebar', () => {
+      useLayoutStore.setState({ sessionsCollapsed: false, rightPanel: null })
+
+      useLayoutStore.getState().openRightPanel('settings')
+
+      expect(useLayoutStore.getState().sessionsCollapsed).toBe(false)
+      expect(useLayoutStore.getState().sessionsAutoCollapsed).toBe(false)
     })
 
     test('closing after an auto-collapse restores the sidebar', () => {

--- a/frontends/ui/src/features/layout/store.ts
+++ b/frontends/ui/src/features/layout/store.ts
@@ -75,7 +75,7 @@ export const useLayoutStore = create<LayoutStore>()(
       openRightPanel: (panel: RightPanelType) =>
         set(
           (state) => {
-            const collapsesSidebar = panel === 'research' || panel === 'data-sources'
+            const collapsesSidebar = panel !== null && panel !== 'settings'
             if (collapsesSidebar && !state.sessionsCollapsed) {
               return { rightPanel: panel, sessionsCollapsed: true, sessionsAutoCollapsed: true }
             }

--- a/frontends/ui/src/features/layout/types.ts
+++ b/frontends/ui/src/features/layout/types.ts
@@ -12,8 +12,18 @@ import type { DataSourceFromAPI } from '@/adapters/api'
 /** Theme mode options */
 export type ThemeMode = 'light' | 'dark' | 'system'
 
-/** Panels that can be opened on the right side */
-export type RightPanelType = 'research' | 'data-sources' | 'settings' | null
+/**
+ * Panels that can be opened on the right side. The first four map one-to-one to
+ * the Deep Research rail items; `settings` remains for the standalone
+ * SettingsPanel and is not surfaced in the rail.
+ */
+export type RightPanelType =
+  | 'data-sources'
+  | 'citations'
+  | 'research'
+  | 'thinking'
+  | 'settings'
+  | null
 
 /** Tabs within the Research panel */
 export type ResearchPanelTab = 'tasks' | 'thinking' | 'report'


### PR DESCRIPTION
#### Overview

Follow-up to #333 (merged). Implements Allan Enemark's deferred Deep Research UI redesign plus the polish items that were split out of #333 to keep that PR tight.

**Changes**
- **Deep Research nav rail** (`DeepResearchRail`): a persistent right-hand rail (Data Sources / Citations / Research / Thinking) that drives a single content panel, replacing the scattered app-bar Data Sources button and tab switching. Data Sources moves out of the app bar into the rail.
- **Panel resize**: a keyboard-accessible drag grip between the chat and the panel, clamped to a sensible min/max; the width transition is disabled while dragging and reduced-motion is respected.
- **Consolidated Citations** (`ResearchSourcesView`): a single sources view with an All / Cited filter. `ThinkingTab` is reduced to a pure step trace (its Sources sub-tab removed, since Citations now owns sources).
- **Polish**: dividers between chat turns, a smoother Sessions-panel collapse animation, and consistent borders/toggles.
- **Review follow-up (Allan)**: a live activity indicator on the rail plus an animated "Deep research in progress" state in the report panel; removed the placeholder Artifacts panel; better spacing on the panel close/stop controls; a chat-area min-width; and a pointer cursor on the rail buttons.

**Follows the #333 review principles**
- **Citations come from the authoritative final-report metadata.** The Citations view derives cited sources from `splitReferences(reportContent)` (the same source `ReportTab` uses), so citation numbers match the report's inline [N] rather than discovery order. Uncited stream reads are shown under "Other sources found", with a stream fallback only when the report has no reference block.
- **No hard-coded data sources** (the rail lists panel names, not sources).
- **Correlation stays id-keyed**; no new name-based matching added.
- **No Markdown-intent guessing** added.
- New panel/width state is UI-only; **no cross-session state** introduced.

#### Screenshots

##### Design vs. @exactlyallan's mockups

**Deep Research rail**

| Allan's mockup | Implemented |
| :-- | :-- |
| ![rail mockup](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/1a-mockup-rail.png) | ![rail implemented](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/1b-actual-rail.png) |

**Research panel**

| Allan's mockup | Implemented |
| :-- | :-- |
| ![research mockup](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/2a-mockup-research.png) | ![research implemented](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/2b-actual-research.png) |

**Data Sources panel**

| Allan's mockup | Implemented |
| :-- | :-- |
| ![data sources mockup](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/3a-mockup-datasources.png) | ![data sources implemented](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/3b-actual-datasources.png) |

##### Deep research, end to end

**Main chat: response summary + "Report Completed" banner**

![main chat](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/actual-mainchat-deepresearch.png)

**Research panel: the final report**

![research report](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/actual-research-report.png)

**Citations: cited [1][2][3] in report order (authoritative numbering)**

![citations](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/actual-citations-populated.png)

**Thinking: live grouped step trace**

![thinking](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/actual-thinking-populated.png)

##### Deep research activity (review follow-up)

**Live activity indicator on the rail (research running)**

![activity](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/actual-rail-activity.png)

**Report panel in-progress state**

![in progress](https://raw.githubusercontent.com/Manushpm8/aiq/ui-followup-shots/assets/actual-report-inprogress.png)

#### DCO sign-off for the squash commit

Signed-off-by: Manush Murali <manushm@nvidia.com>
Signed-off-by: Manush Murali <91221099+Manushpm8@users.noreply.github.com>

#### Validation

- `npm run lint` (0 errors), `npm run type-check` (clean), `npm run test:ci` (**1773 passed, 1 skipped**), `npm run build` (compiles).
- `tests/aiq_agent/test_default_model_profiles.py::test_deprecated_model_and_endpoint_references_are_absent` passes (no deprecated model/endpoint strings in the diff).
- New/updated tests: `ResearchSourcesView` authoritative-order test (cited numbers follow the report [N], not discovery order); `DeepResearchRail`, panel-resize, store auto-collapse, and `ThinkingTab`-no-Sources-subtab specs.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] Docs: no changes needed; this is UI-internal panel behavior not covered by the Sphinx docs.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s`.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

- `frontends/ui/src/features/layout/components/ResearchSourcesView.tsx` — authoritative citation derivation (the highest-risk area from the #333 review).
- `frontends/ui/src/features/layout/components/DeepResearchRail.tsx` and `ResearchPanel.tsx` — the rail model and the drag-to-resize.

#### Related Issues

- Relates to #333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent Deep Research rail for Research, Data Sources, Citations, Artifacts, and Thinking panels.
  * Added source filtering, citation numbering, empty states, and clearer source organization.
  * Added collapsible task progress, generated file sections, panel resizing, and panel-specific loading states.
* **Improvements**
  * Removed Data Sources from the app bar.
  * Improved conversation turn separation and sidebar collapse behavior.
  * Simplified the Thinking view by removing redundant sub-tabs and citation cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

