### PR TITLE
fix: restore 2.2.1 release readiness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -62,6 +62,7 @@ tests/
 !mcp/README.md
 !sources/knowledge_layer/README.md
 !sources/tavily_web_search/README.md
+!src/aiq_agent/agents/deep_researcher/skills/**/SKILL.md
 docs/
 license_report.pdf
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,9 @@ jobs:
           chmod +x ci/scripts/test_scripts.sh
           ci/scripts/test_scripts.sh --skip-setup
 
+      - name: Validate VCS-less AI-Q release artifact
+        run: ci/scripts/test_release_artifact.sh
+
       - name: Create MCP production environment
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,9 @@ jobs:
           chmod +x ci/scripts/test_scripts.sh
           ci/scripts/test_scripts.sh --skip-setup
 
-      - name: Validate VCS-less AI-Q release artifact
+      - name: Validate VCS-less AI-Q release artifact on Python 3.11
+        env:
+          UV_PYTHON: "3.11"
         run: ci/scripts/test_release_artifact.sh
 
       - name: Create MCP production environment

--- a/ci/scripts/test_release_artifact.sh
+++ b/ci/scripts/test_release_artifact.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Validate the installable AI-Q artifact without relying on checkout metadata or
+# editable imports. CI intentionally runs this against the committed HEAD.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+SOURCE_ROOT="$TMP_ROOT/source"
+WHEEL_DIR="$TMP_ROOT/wheel"
+VENV_DIR="$TMP_ROOT/venv"
+RUNTIME_ROOT="$TMP_ROOT/runtime"
+
+cleanup() {
+    rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$SOURCE_ROOT" "$WHEEL_DIR" "$RUNTIME_ROOT"
+git -C "$REPO_ROOT" archive HEAD | tar -xf - -C "$SOURCE_ROOT"
+if [[ -e "$SOURCE_ROOT/.git" ]]; then
+    echo "Release source export unexpectedly contains .git metadata" >&2
+    exit 1
+fi
+
+uv build --wheel --out-dir "$WHEEL_DIR" "$SOURCE_ROOT"
+wheel_count=$(find "$WHEEL_DIR" -maxdepth 1 -type f -name 'aiq_agent-*.whl' | wc -l | tr -d ' ')
+if [[ "$wheel_count" != "1" ]]; then
+    echo "Expected exactly one aiq-agent wheel, found $wheel_count" >&2
+    exit 1
+fi
+WHEEL_PATH=$(find "$WHEEL_DIR" -maxdepth 1 -type f -name 'aiq_agent-*.whl')
+
+UV_PROJECT_ENVIRONMENT="$VENV_DIR" \
+    uv sync --project "$SOURCE_ROOT" --frozen --group dev --no-editable --no-install-package aiq-agent
+uv pip install --python "$VENV_DIR/bin/python" --no-deps --reinstall "$WHEEL_PATH"
+uv pip check --python "$VENV_DIR/bin/python"
+
+cp -R "$SOURCE_ROOT/configs" "$RUNTIME_ROOT/configs"
+cd "$RUNTIME_ROOT"
+
+"$VENV_DIR/bin/python" -I - "$SOURCE_ROOT" "$WHEEL_PATH" <<'PY'
+import importlib.metadata
+import sys
+import zipfile
+from pathlib import Path
+
+import aiq_agent
+
+source_root = Path(sys.argv[1]).resolve()
+wheel_path = Path(sys.argv[2]).resolve()
+expected = {
+    "aiq_agent/agents/chat_researcher/prompts/context_aware_intent_router.j2",
+    "aiq_agent/agents/chat_researcher/prompts/intent_classification.j2",
+    "aiq_agent/agents/clarifier/prompts/research_clarification.j2",
+    "aiq_agent/agents/deep_researcher/prompts/orchestrator.j2",
+    "aiq_agent/agents/deep_researcher/prompts/planner.j2",
+    "aiq_agent/agents/deep_researcher/prompts/researcher.j2",
+    "aiq_agent/agents/deep_researcher/prompts/source_registry.j2",
+    "aiq_agent/agents/deep_researcher/prompts/source_router.j2",
+    "aiq_agent/agents/deep_researcher/prompts/writer.j2",
+    "aiq_agent/agents/report_rewriter/prompts/edit.j2",
+    "aiq_agent/agents/shallow_researcher/prompts/researcher.j2",
+    "aiq_agent/agents/deep_researcher/skills/research/data-table-analysis/SKILL.md",
+    "aiq_agent/agents/deep_researcher/skills/research/forecast-analysis/SKILL.md",
+    "aiq_agent/agents/deep_researcher/skills/research/lightweight-calculation/SKILL.md",
+    "aiq_agent/agents/deep_researcher/skills/synthesis/long-form-report-writer/SKILL.md",
+    "aiq_agent/agents/deep_researcher/skills/synthesis/prediction-report-writer/SKILL.md",
+    "aiq_agent/agents/deep_researcher/skills/visualization/chart-generation/SKILL.md",
+}
+
+source_package = source_root / "src" / "aiq_agent"
+actual_source = {
+    path.relative_to(source_root / "src").as_posix()
+    for path in (source_package / "agents").glob("*/prompts/*.j2")
+}
+actual_source.update(
+    path.relative_to(source_root / "src").as_posix()
+    for path in (source_package / "agents" / "deep_researcher" / "skills").rglob("SKILL.md")
+)
+if actual_source != expected:
+    raise SystemExit(
+        "Runtime asset manifest is stale: "
+        f"missing={sorted(expected - actual_source)}, unexpected={sorted(actual_source - expected)}"
+    )
+
+for relative in expected:
+    source_path = source_root / "src" / relative
+    if source_path.stat().st_size == 0:
+        raise SystemExit(f"Source runtime asset is empty: {relative}")
+
+with zipfile.ZipFile(wheel_path) as wheel:
+    wheel_entries = {entry.filename: entry.file_size for entry in wheel.infolist()}
+for relative in expected:
+    if wheel_entries.get(relative, 0) == 0:
+        raise SystemExit(f"Wheel runtime asset is missing or empty: {relative}")
+
+package_root = Path(aiq_agent.__file__).resolve().parent
+venv_root = Path(sys.prefix).resolve()
+try:
+    package_root.relative_to(venv_root)
+except ValueError as exc:
+    raise SystemExit(f"aiq_agent imported outside the isolated environment: {package_root}") from exc
+if source_root in package_root.parents:
+    raise SystemExit(f"aiq_agent imported from the source export: {package_root}")
+
+for relative in expected:
+    installed_path = package_root / Path(relative).relative_to("aiq_agent")
+    if not installed_path.is_file() or installed_path.stat().st_size == 0:
+        raise SystemExit(f"Installed runtime asset is missing or empty: {relative}")
+
+direct_url = importlib.metadata.distribution("aiq-agent").read_text("direct_url.json") or ""
+if '"editable": true' in direct_url:
+    raise SystemExit("aiq-agent was installed editable")
+
+print(f"Verified {len(expected)} non-empty runtime assets in source, wheel, and installed distribution")
+print(f"Verified isolated aiq_agent import: {aiq_agent.__file__}")
+PY
+
+export NVIDIA_API_KEY="ci-not-a-real-key"  # pragma: allowlist secret
+export OPENAI_API_KEY="ci-not-a-real-key"  # pragma: allowlist secret
+export TAVILY_API_KEY="ci-not-a-real-key"  # pragma: allowlist secret
+export SERPER_API_KEY="ci-not-a-real-key"  # pragma: allowlist secret
+export REDIS_PASSWORD="ci-not-a-real-password"  # pragma: allowlist secret
+export NAT_JOB_STORE_DB_URL="sqlite+aiosqlite:///$RUNTIME_ROOT/jobs.db"
+export AIQ_CHECKPOINT_DB="$RUNTIME_ROOT/checkpoints.db"
+export AIQ_SUMMARY_DB="sqlite+aiosqlite:///$RUNTIME_ROOT/summaries.db"
+export AIQ_CHROMA_DIR="$RUNTIME_ROOT/chroma"
+export AZURE_SEARCH_ENDPOINT="https://azure-search.invalid"
+export MCP_TOKEN_DB="$RUNTIME_ROOT/mcp_tokens.db"
+export AIQ_OPENSHELL_POLICY_FILE="$RUNTIME_ROOT/configs/openshell/aiq-research-policy.yaml"
+
+config_count=0
+while IFS= read -r config_path; do
+    config_count=$((config_count + 1))
+    echo "Validating installed workflow: ${config_path#"$RUNTIME_ROOT/"}"
+    "$VENV_DIR/bin/nat" validate --config_file "$config_path"
+done < <(find "$RUNTIME_ROOT/configs" -maxdepth 1 -type f -name 'config_*.yml' | sort)
+
+if [[ "$config_count" -eq 0 ]]; then
+    echo "No shipped top-level workflow configs were discovered" >&2
+    exit 1
+fi
+echo "Validated $config_count shipped top-level workflow configs from the installed release artifact"

--- a/docs/source/customization/knowledge-layer.md
+++ b/docs/source/customization/knowledge-layer.md
@@ -281,8 +281,6 @@ Persisted vector stores are tied to both the embedding model and its output dime
 - **Azure AI Search:** model and dimension are part of the physical index identity; changing either creates an isolated
   index that must be populated by re-ingestion.
 
-See the detailed [knowledge-layer setup migration procedure](../../../sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md#migrating-an-embedding-model).
-
 OpenSearch ingestion is text-only: it extracts text from PDF, DOCX, PPTX, and supported plain-text formats, but does not
 perform LlamaIndex table/image/chart extraction. Distributed Dask ingestion also disables document-summary generation
 because the configured summary LLM is not serialized to workers; use local ingestion when summaries are required.

--- a/docs/source/deployment/docker-compose.md
+++ b/docs/source/deployment/docker-compose.md
@@ -164,7 +164,7 @@ See [Production Considerations](./production.md#s3-security-responsibility).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `backend_url` | `http://aiq-agent:8000` | Backend API URL as seen from the frontend container. |
+| `BACKEND_URL` | `http://aiq-agent:8000` | Backend API URL as seen from the frontend container. |
 
 ### Dask Worker Settings
 

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -109,13 +109,25 @@ instrument LangChain directly can present a different tree.
 
 ## Weights & Biases Weave
 
-[Weave](https://wandb.ai/site/weave) provides experiment tracking and trace logging integrated with the Weights & Biases platform. NAT includes Weave support via the `weave` extra (`nvidia-nat[weave]`), which is already installed in this project.
+[Weave](https://wandb.ai/site/weave) provides experiment tracking and trace
+logging integrated with the Weights & Biases platform. Weave support is an
+optional NAT extra and is not installed by default.
 
 ### Setup
 
-1. Create a [Weights & Biases](https://wandb.ai/) account if you do not have one.
+1. Install the exporter into your local environment:
 
-2. Set the API key in `deploy/.env`:
+   ```bash
+   uv pip install "nvidia-nat[weave]==1.8.0"
+   ```
+
+   For production or container deployments, add this exact pinned dependency
+   to the image build and rebuild the image. Installing it into a running
+   container is not a durable deployment.
+
+2. Create a [Weights & Biases](https://wandb.ai/) account if you do not have one.
+
+3. Set the API key in `deploy/.env`:
 
    ```bash
    WANDB_API_KEY=your-wandb-api-key
@@ -127,7 +139,7 @@ instrument LangChain directly can present a different tree.
    wandb login
    ```
 
-3. Enable Weave tracing in your YAML config:
+4. Enable Weave tracing in your YAML config:
 
    ```yaml
    general:

--- a/docs/source/deployment/production.md
+++ b/docs/source/deployment/production.md
@@ -199,15 +199,15 @@ production artifact storage.
 
 ### Horizontal Backend Scaling
 
-The backend is stateless apart from database connections, so it can be horizontally scaled behind a load balancer.
+The shipped Docker Compose topology supports one backend instance. Do not use
+Compose service scaling for production because the stack does not provide the
+required backend load balancer or shared scheduler topology.
 
-**Docker Compose:** Run multiple backend containers by scaling the service and using a reverse proxy (such as Traefik or NGINX) in front:
+For production horizontal scaling, deploy with Helm and set
+`aiq.apps.backend.replicas` or the `aiq.apps.backend.autoscaling` values. Refer
+to [Kubernetes and Helm](./kubernetes.md) for the supported deployment path.
 
-```bash
-docker compose --env-file ../.env -f docker-compose.yaml up -d --scale aiq-agent=3
-```
-
-Note that each scaled instance starts its own embedded Dask scheduler and worker.
+Each backend replica starts its own embedded Dask scheduler and worker.
 The shipped container entrypoint always creates that embedded cluster. A deployment
 that uses a shared Dask cluster must provide a custom entrypoint (for example,
 starting `/app/deploy/start_web.py` directly), set

--- a/docs/source/evaluation/benchmarks/deep-research-bench.md
+++ b/docs/source/evaluation/benchmarks/deep-research-bench.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 ```bash
 export TAVILY_API_KEY=your_key              # For web search
+export SERPER_API_KEY=your_key              # For Google Scholar paper search
 export NVIDIA_API_KEY=your_key              # For agent execution (integrate.api.nvidia.com)
 export OPENAI_API_KEY=your_key              # For frontier model in config (optional)
 ```

--- a/docs/source/examples/full-pipeline-web.md
+++ b/docs/source/examples/full-pipeline-web.md
@@ -258,12 +258,22 @@ The server starts at `http://localhost:8000`. The API docs are at `http://localh
 
 ### Docker Compose
 
+The FRAG workflow requires separately deployed RAG query and ingestion services.
+Set both endpoints to addresses that are reachable from the `aiq-agent`
+container. Container-local `localhost` points back to the AI-Q backend and is not
+a valid cross-service address.
+
+From the repository root:
+
 ```bash
-cd deploy
-cp .env.example .env
-# Edit .env with your API keys and set:
+cp deploy/.env.example deploy/.env
+# Edit deploy/.env with your API keys and these container-reachable values:
 # BACKEND_CONFIG=/app/configs/config_web_frag.yml
-docker compose up
+# RAG_SERVER_URL=http://rag-server:8081/v1
+# RAG_INGEST_URL=http://ingestor-server:8082/v1
+docker compose --env-file deploy/.env \
+  -f deploy/compose/docker-compose.yaml \
+  up -d --build --wait
 ```
 
 ### Test the Pipeline

--- a/docs/source/examples/full-pipeline-web.md
+++ b/docs/source/examples/full-pipeline-web.md
@@ -276,6 +276,15 @@ docker compose --env-file deploy/.env \
   up -d --build --wait
 ```
 
+With the service-name endpoints shown above and both stacks running, connect
+the AI-Q backend to the RAG network:
+
+```bash
+docker network connect nvidia-rag aiq-agent
+```
+
+Repeat this command whenever the `aiq-agent` container is recreated.
+
 ### Test the Pipeline
 
 ```bash

--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -228,9 +228,14 @@ Each skill should be a directory with a `SKILL.md` file:
 
 ```text
 src/aiq_agent/agents/deep_researcher/skills/
-`-- my-skill/
-    `-- SKILL.md
+`-- research/
+    `-- my-skill/
+        `-- SKILL.md
 ```
+
+The required hierarchy is `skills/<collection>/<skill>/SKILL.md`. The
+collection directory is the public name assigned to an agent in
+`deep_research_skills.agents`.
 
 At minimum, `SKILL.md` needs frontmatter with a stable `name` and a clear `description`:
 
@@ -262,14 +267,18 @@ Skill descriptions matter because DeepAgents uses the frontmatter description to
 
 To add a built-in AI-Q deep research skill:
 
-1. Create a new directory under `src/aiq_agent/agents/deep_researcher/skills/`.
+1. Create `src/aiq_agent/agents/deep_researcher/skills/<collection>/<skill>/`.
 2. Add a `SKILL.md` file with frontmatter and workflow instructions.
 3. Put optional helper scripts, references, or templates inside the same skill directory.
 4. Reference any helper files from `SKILL.md` so the agent knows when to read or run them.
 5. Keep workflow instructions generic enough to handle variations of the task, but concrete enough to force required tool calls.
 6. Run with `configs/config_domain_routing_and_skills.yml` and test a query that should trigger the new skill.
 
-No config change is required for additional built-in skills inside an enabled collection. AI-Q collects available skill directories at runtime and exposes them to DeepAgents through an internal `/skills/` source.
+A skill added to a collection that is already assigned to the target agent needs
+no config change. For a new collection, add the collection name to the target
+agent under `deep_research_skills.agents`. AI-Q collects the assigned skill
+directories at runtime and exposes them to DeepAgents through an internal
+`/skills/` source.
 
 ## Notes and Limitations
 

--- a/docs/source/extending/adding-a-data-source.md
+++ b/docs/source/extending/adding-a-data-source.md
@@ -257,7 +257,7 @@ version = "1.0.0"
 description = "NAT-based patent search data source"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "nvidia-nat==1.5.0",
+    "nvidia-nat-core==1.8.0",
     "httpx>=0.24.0",
     "pydantic>=2.0.0",
 ]
@@ -405,11 +405,14 @@ The LLM will use the parameter descriptions to decide which filters to apply.
 
 Format results so the agent can extract citations. Use a consistent pattern:
 
-```python
-# XML Document format (matches Tavily pattern)
-f'<Document href="{url}">\n<title>\n{title}\n</title>\n{content}\n</Document>'
+For pseudo-XML output, use the
+[fixed-shape renderer pattern](./adding-a-tool.md#output-formatting), which
+escapes every provider-controlled field before interpolation. Do not insert raw
+provider output into markup.
 
-# Or structured text format
+For a plain structured-text alternative:
+
+```python
 f"**{title}** ({id})\nAbstract: {abstract}\nLink: {url}"
 ```
 

--- a/docs/source/extending/adding-a-tool.md
+++ b/docs/source/extending/adding-a-tool.md
@@ -99,10 +99,32 @@ The tool function is what the LLM invokes. It must have clear type annotations a
 ```python
 # sources/my_search_tool/src/my_client.py
 
-import httpx
+import html
 import logging
+import re
+
+import httpx
 
 logger = logging.getLogger(__name__)
+
+_INVALID_XML_CHARACTERS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF\uFFFE\uFFFF]")
+
+
+def _xml_text(value: object) -> str:
+    """Normalize provider text and remove characters forbidden by XML 1.0."""
+    return _INVALID_XML_CHARACTERS.sub("", "" if value is None else str(value))
+
+
+def _render_document(url: object, title: object, content: object) -> str:
+    """Render provider-controlled fields inside the trusted document structure."""
+    url_text = _xml_text(url)
+    title_text = _xml_text(title)
+    content_text = _xml_text(content)
+    return (
+        f'<Document href="{html.escape(url_text, quote=True)}">\n'
+        f"<title>\n{html.escape(title_text, quote=True)}\n</title>\n"
+        f"{html.escape(content_text, quote=True)}\n</Document>"
+    )
 
 
 class MySearchClient:
@@ -130,13 +152,12 @@ class MySearchClient:
 
         formatted = []
         for doc in results:
-            url = doc.get("url", "")
-            title = doc.get("title", "")
-            content = doc.get("content", "")
             formatted.append(
-                f'<Document href="{url}">\n'
-                f"<title>\n{title}\n</title>\n"
-                f"{content}\n</Document>"
+                _render_document(
+                    doc.get("url"),
+                    doc.get("title"),
+                    doc.get("content"),
+                )
             )
 
         return "\n\n---\n\n".join(formatted)
@@ -320,8 +341,11 @@ dotenv -f deploy/.env run .venv/bin/nat run \
 ```python
 # sources/my_search_tool/tests/test_my_tool.py
 
+import xml.etree.ElementTree as ET
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import AsyncMock, patch
 
 from my_search_tool.my_client import MySearchClient
 
@@ -329,9 +353,12 @@ from my_search_tool.my_client import MySearchClient
 @pytest.mark.asyncio
 async def test_search_returns_results():
     """Test that the search client returns formatted results."""
+    url = 'https://example.com/pa\x00th?q="quoted"&close=</Document>'
+    title = 'Example\x00 & "title" </title>'
+    content = "Example\x00 result & </Document>"
     mock_response = {
         "results": [
-            {"url": "https://example.com", "content": "Example result"},
+            {"url": url, "title": title, "content": content},
         ]
     }
 
@@ -345,8 +372,14 @@ async def test_search_returns_results():
         )
         result = await client.search("test query")
 
-    assert "Example result" in result
-    assert "example.com" in result
+    assert result.count("<Document ") == 1
+    assert result.count("</Document>") == 1
+    document = ET.fromstring(result)
+    title_element = document.find("title")
+    assert title_element is not None
+    assert document.attrib["href"] == url.replace("\x00", "")
+    assert (title_element.text or "").strip("\n") == title.replace("\x00", "")
+    assert (title_element.tail or "").strip("\n") == content.replace("\x00", "")
 
 
 @pytest.mark.asyncio
@@ -412,25 +445,17 @@ async def _search(query: str) -> str:
 
 ### Output Formatting
 
-Use the XML `<Document>` format for results that include URLs. This allows the agent's prompt to extract and cite sources:
+Use the XML `<Document>` format for results that include URLs. This allows the agent's prompt to extract and cite sources.
+Reuse the private `_render_document()` helper from Step 3:
 
 ```python
-import html
-
-
-def _render_document(url: str | None, title: str | None, content: str | None) -> str:
-    safe_url = html.escape("" if url is None else url, quote=True)
-    safe_title = html.escape("" if title is None else title)
-    safe_content = html.escape("" if content is None else content)
-    return f'<Document href="{safe_url}">\n<title>\n{safe_title}\n</title>\n{safe_content}\n</Document>'
-
-
 result = _render_document(url, title, content)
 ```
 
 Keep this renderer private to the independently installable plugin and preserve
-the fixed document shape. Escaping provider-controlled values prevents them
-from closing trusted tags or creating additional document elements.
+the fixed document shape. Removing XML 1.0-invalid code points and escaping
+provider-controlled values prevents them from breaking the fragment, closing
+trusted tags, or creating additional document elements.
 
 ---
 

--- a/docs/source/extending/adding-a-tool.md
+++ b/docs/source/extending/adding-a-tool.md
@@ -238,7 +238,7 @@ version = "1.0.0"
 description = "NAT-based custom search tool"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "nvidia-nat==1.5.0",
+    "nvidia-nat-core==1.8.0",
     "httpx>=0.24.0",
     "pydantic>=2.0.0",
 ]
@@ -251,7 +251,7 @@ Key points:
 
 - The `package-dir` maps the package name to `src/` so Python can find your module.
 - The entry point key (`my_search_tool`) maps to the `register` module, which triggers `@register_function` at import time.
-- Pin `nvidia-nat` to the same version used by the main project.
+- Pin `nvidia-nat-core` to the same version used by the main project.
 
 ---
 
@@ -415,8 +415,22 @@ async def _search(query: str) -> str:
 Use the XML `<Document>` format for results that include URLs. This allows the agent's prompt to extract and cite sources:
 
 ```python
-f'<Document href="{url}">\n<title>\n{title}\n</title>\n{content}\n</Document>'
+import html
+
+
+def _render_document(url: str | None, title: str | None, content: str | None) -> str:
+    safe_url = html.escape("" if url is None else url, quote=True)
+    safe_title = html.escape("" if title is None else title)
+    safe_content = html.escape("" if content is None else content)
+    return f'<Document href="{safe_url}">\n<title>\n{safe_title}\n</title>\n{safe_content}\n</Document>'
+
+
+result = _render_document(url, title, content)
 ```
+
+Keep this renderer private to the independently installable plugin and preserve
+the fixed document shape. Escaping provider-controlled values prevents them
+from closing trusted tags or creating additional document elements.
 
 ---
 

--- a/docs/source/get-started/installation.md
+++ b/docs/source/get-started/installation.md
@@ -45,7 +45,7 @@ self-hosted Lightning option.
 The setup script handles everything -- virtual environment, Python dependencies, and UI dependencies:
 
 ```bash
-git clone <repository-url>
+git clone https://github.com/NVIDIA-AI-Blueprints/aiq.git
 cd aiq
 
 ./scripts/setup.sh

--- a/docs/source/integration/agent-skills.md
+++ b/docs/source/integration/agent-skills.md
@@ -104,7 +104,7 @@ After the skills are installed, users can ask their coding harness for AI-Q acti
 
 ## Prerequisites
 
-- Python 3.10 or newer.
+- Python 3.11 or newer.
 - For `aiq-deploy`: access to this repository or permission to clone `https://github.com/NVIDIA-AI-Blueprints/aiq`, plus the selected runtime such as Docker Compose, Node/npm for local web mode, or kubectl/Helm for Kubernetes mode.
 - For `aiq-research`: a local or self-hosted AI-Q Blueprint server, usually at `http://localhost:8000`. Set `AIQ_SERVER_URL` only when using a different local or self-hosted server URL.
 

--- a/docs/source/integration/agent-skills.md
+++ b/docs/source/integration/agent-skills.md
@@ -104,7 +104,7 @@ After the skills are installed, users can ask their coding harness for AI-Q acti
 
 ## Prerequisites
 
-- Python 3.11 or newer.
+- Python 3.11, 3.12, or 3.13.
 - For `aiq-deploy`: access to this repository or permission to clone `https://github.com/NVIDIA-AI-Blueprints/aiq`, plus the selected runtime such as Docker Compose, Node/npm for local web mode, or kubectl/Helm for Kubernetes mode.
 - For `aiq-research`: a local or self-hosted AI-Q Blueprint server, usually at `http://localhost:8000`. Set `AIQ_SERVER_URL` only when using a different local or self-hosted server URL.
 

--- a/frontends/aiq_api/src/aiq_api/plugin.py
+++ b/frontends/aiq_api/src/aiq_api/plugin.py
@@ -38,7 +38,6 @@ import logging
 import os
 import signal
 from collections.abc import Callable
-from typing import override
 
 from fastapi import APIRouter
 from fastapi import FastAPI
@@ -52,6 +51,7 @@ from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfi
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorkerBase
+from nat.utils.type_utils import override
 
 from .jobs.connection_manager import get_connection_manager
 from .jobs.event_store import EventStore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,11 @@ requires = ["setuptools >= 83", "setuptools-scm>=8"]
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-"aiq_agent.agents.deep_researcher" = ["skills/**/*"]
+"aiq_agent.agents.chat_researcher" = ["prompts/*.j2"]
+"aiq_agent.agents.clarifier" = ["prompts/*.j2"]
+"aiq_agent.agents.deep_researcher" = ["prompts/*.j2", "skills/**/*"]
+"aiq_agent.agents.report_rewriter" = ["prompts/*.j2"]
+"aiq_agent.agents.shallow_researcher" = ["prompts/*.j2"]
 
 [project]
 name = "aiq-agent"

--- a/src/aiq_agent/fastapi_extensions/register.py
+++ b/src/aiq_agent/fastapi_extensions/register.py
@@ -23,7 +23,6 @@ as sources/knowledge_layer/src/register.py.
 
 import logging
 import os
-from typing import override
 
 from fastapi import FastAPI
 from pydantic import Field
@@ -36,6 +35,7 @@ from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfi
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorkerBase
+from nat.utils.type_utils import override
 
 from .routes.collections import add_collection_routes
 from .routes.documents import add_document_routes


### PR DESCRIPTION
#### Overview

This PR restores AI-Q 2.2.1 release readiness by shipping the runtime files customers need and correcting the operator and developer instructions that QA found were not executable as written.

| Question | Answer |
|---|---|
| **P0-01 — Will a normal, non-editable AI-Q wheel contain every prompt and built-in skill required at runtime?** | Yes: package metadata now owns all 11 prompt templates and six built-in `SKILL.md` files, and a VCS-less artifact gate proves all 17 files are present, non-empty, installed, and loadable outside the checkout. |
| **P1-06 — Do the operator instructions match the deployment behavior AI-Q actually supports?** | Yes: the docs now use `BACKEND_URL`, direct production scaling to Helm, give the repository-root Compose command, mark Weave as an optional pinned dependency, add the missing benchmark key, and explain the external FRAG endpoints. |
| **P1-06 — Can developers follow the extension and onboarding examples safely?** | Yes: the docs now show the real skill hierarchy, supported `nvidia-nat-core==1.8.0` dependency, an escaped fixed-shape renderer, Python 3.11+, and the concrete public clone URL. |

The three commits remain independently reviewable: runtime packaging, operator documentation, and developer documentation.

Compatibility and scope:

- No prompt contents, agent instructions, routing, model selection, workflow configuration, public API, or deployment manifest changed.
- Root and MCP lockfiles are unchanged; Weave remains opt-in and is not installed by default.
- Docker Compose remains a supported single-backend topology; production horizontal scaling uses the existing Helm values.
- Brev launchable pinning (P0-02), the standalone `aiq-debug` HTML asset, and deferred backlog items remain out of scope.
- Rebuilding and publishing the rendered documentation remains a post-merge release step.

#### DCO sign-off for the squash commit

Signed-off-by: Kyle Zheng <kyzheng@nvidia.com>

#### Validation

Direct installed-artifact acceptance test:

```bash
./ci/scripts/test_release_artifact.sh
echo $?
```

Result: exit `0`, with the following final evidence:

```text
Verified 17 non-empty runtime assets in source, wheel, and installed distribution
Validated 11 shipped top-level workflow configs from the installed release artifact
0
```

The gate builds from a `git archive` export with no `.git` metadata, installs the exact wheel non-editably into an isolated environment, checks import provenance, verifies every asset, and validates every shipped top-level workflow config from installed packages.

Additional completed validation:

- Root and MCP frozen-lock checks passed; neither lockfile changed.
- Documentation HTML built with warnings treated as errors, and Sphinx link checking passed.
- The existing MCP production Compose lane built successfully; `/live` returned `alive`, `/health` returned `ready`, and protocol smoke discovered `submit_query`, `poll_query`, and `get_final_report` before clean teardown.
- Pre-commit and `git diff --check` passed.

Reviewer reproduction — package contents:

```bash
./ci/scripts/test_release_artifact.sh
```

The script must end with the 11-config validation line above and exit `0`; starting AI-Q from a source checkout alone does not prove P0-01 because local files can mask missing wheel data.

Reviewer reproduction — documentation:

```bash
uv sync --extra docs
uv run make -C docs html SPHINXOPTS="-W --keep-going"
uv run make -C docs linkcheck
```

Reviewer reproduction — deployment examples:

```bash
docker compose --env-file deploy/.env \
  -f deploy/compose/docker-compose.yaml \
  config --quiet

helm dependency build deploy/helm/deployment-k8s
helm template aiq deploy/helm/deployment-k8s \
  --set aiq.apps.backend.replicas=3 >/dev/null
helm template aiq deploy/helm/deployment-k8s \
  --set aiq.apps.backend.autoscaling.enabled=true >/dev/null
```

For a full FRAG launch, set `BACKEND_CONFIG=/app/configs/config_web_frag.yml` plus container-reachable `RAG_SERVER_URL` and `RAG_INGEST_URL`, then run:

```bash
docker compose --env-file deploy/.env \
  -f deploy/compose/docker-compose.yaml \
  up -d --build --wait
```

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

1. Review `pyproject.toml` with `ci/scripts/test_release_artifact.sh` for the package-data ownership and installed-wheel contract.
2. Review the operator documentation commit for Compose, Helm scaling, observability, benchmark, and FRAG corrections.
3. Review the developer documentation commit for skill discovery, extension dependency/rendering, Python, and clone corrections.

#### Related Issues

- Relates to AI-Q 2.2.1 QA items P0-01 and P1-06.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured packaged releases include required prompts and skill assets when installed outside the source repository.
  - Corrected Docker Compose environment variable guidance and container service connectivity instructions.
  - Improved safe handling of provider-supplied document content in generated output.
  - Clarified production scaling limitations and recommended deployment approach.

- **Documentation**
  - Updated setup, Agent Skills, observability, benchmarking, and extension guides with current requirements.
  - Expanded skill collection configuration and runtime access guidance.

- **Tests**
  - Added automated validation for release artifacts, installation, imports, assets, and workflow configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->