### PR TITLE
Fix empty response issue for shallow agent

### DIFF
--- a/docs/source/architecture/agents/shallow-researcher.md
+++ b/docs/source/architecture/agents/shallow-researcher.md
@@ -100,6 +100,7 @@ Configured through `ShallowResearchAgentConfig` (NeMo Agent Toolkit type name: `
 | `tools` | `list[FunctionRef \| FunctionGroupRef]` | `[]` | Tools available for research (web search, document search, etc.) |
 | `max_llm_turns` | `int` | `10` | Maximum LLM interaction turns |
 | `max_tool_iterations` | `int` | `5` | Maximum tool calls before forcing synthesis |
+| `enforce_citations` | `bool` | `false` | Fail instead of returning a sanitized generated answer when citation integrity cannot be preserved |
 | `verbose` | `bool` | `false` | Enable verbose logging |
 
 **Example YAML:**
@@ -113,6 +114,7 @@ functions:
       - web_search_tool
     max_llm_turns: 10
     max_tool_iterations: 5
+    enforce_citations: false
     verbose: true
 ```
 

--- a/docs/source/customization/configuration-reference.md
+++ b/docs/source/customization/configuration-reference.md
@@ -428,7 +428,7 @@ functions:
 
 ### `shallow_research_agent`
 
-Fast, single-pass research agent that produces citation-backed answers in one tool-calling loop.
+Fast, single-pass research agent that attempts to produce citation-backed answers in one tool-calling loop.
 
 ```yaml
 functions:
@@ -440,6 +440,7 @@ functions:
       - knowledge_search
     max_llm_turns: 10
     max_tool_iterations: 5
+    enforce_citations: false
     verbose: true
 ```
 
@@ -449,6 +450,7 @@ functions:
 | `tools` | `list[str]` | `[]` | Search tools available to the agent. |
 | `max_llm_turns` | `int` | `10` | Maximum number of LLM turns (includes both reasoning and tool-calling steps). |
 | `max_tool_iterations` | `int` | `5` | Maximum tool-calling iterations before forcing synthesis. |
+| `enforce_citations` | `bool` | `false` | Fail the run when citation integrity cannot be preserved. When `false`, AI-Q returns the generated answer after sanitization instead of failing solely on the citation contract. |
 | `verbose` | `bool` | `false` | Enable verbose logging. |
 
 ### `deep_research_agent`

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -1312,6 +1312,7 @@ def _create_agent_instance(
             llm_provider=llm_provider,
             tools=tools,
             max_tool_iterations=getattr(fn_config, "max_tool_iterations", 5),
+            enforce_citations=getattr(fn_config, "enforce_citations", False),
             callbacks=callbacks,
         )
     except TypeError:

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -96,6 +96,17 @@ def _job_escalation_message(kind: str, job_id: str) -> str:
     return json.dumps({"type": "job_escalation", "kind": kind, "job_id": job_id})
 
 
+def _is_blank_message_content(content: Any) -> bool:
+    """Return True when a model message has no user-visible text."""
+    if content is None:
+        return True
+    if isinstance(content, str):
+        return not content.strip()
+    if isinstance(content, list):
+        return not any(str(item).strip() for item in content)
+    return not str(content).strip()
+
+
 class ChatResearcherAgent:
     """
     Orchestrates the full chat research workflow.
@@ -329,6 +340,16 @@ class ChatResearcherAgent:
                 None,
             )
             if final_ai_message:
+                if _is_blank_message_content(final_ai_message.content):
+                    logger.warning("Shallow research returned an empty final response; escalating to deep research")
+                    return {
+                        "shallow_result": ShallowResult(
+                            answer="",
+                            confidence="low",
+                            escalate_to_deep=True,
+                            escalation_reason="Shallow research returned an empty final response",
+                        )
+                    }
                 return {"messages": [final_ai_message], "shallow_result": None}
             if new_messages:
                 return {"messages": [new_messages[-1]], "shallow_result": None}
@@ -555,13 +576,13 @@ class ChatResearcherAgent:
                 if isinstance(m, AIMessage):
                     last_ai_content = m.content if hasattr(m, "content") else str(m)
                     break
-            if not last_ai_content:
+            if last_ai_content is None:
                 return END
 
-            last_content = last_ai_content if isinstance(last_ai_content, str) else str(last_ai_content)
-            if not last_content.strip():
+            if _is_blank_message_content(last_ai_content):
                 return "deep_research"
 
+            last_content = last_ai_content if isinstance(last_ai_content, str) else str(last_ai_content)
             tail = last_content[-800:].lower() if len(last_content) > 800 else last_content.lower()
             escalation_keywords = ["i don't have enough information", "unable to find", "need more research"]
             if any(kw in tail for kw in escalation_keywords):

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -259,6 +259,7 @@ class ShallowResearcherAgent:
         max_llm_turns: int = 10,
         max_tool_iterations: int = 5,
         citation_repair_timeout: float = 60.0,
+        enforce_citations: bool = False,
         callbacks: list[Any] | None = None,
     ) -> None:
         """
@@ -274,6 +275,9 @@ class ShallowResearcherAgent:
                                 synthesis (default 5).
             citation_repair_timeout: Maximum seconds for the one-shot citation
                                      repair call (default 60).
+            enforce_citations: Whether missing or invalid citation integrity
+                               should fail the run instead of returning the
+                               generated answer (default False).
             callbacks: Optional list of LangGraph callbacks.
         """
         self.llm_provider = llm_provider
@@ -281,6 +285,7 @@ class ShallowResearcherAgent:
         self.max_llm_turns = max_llm_turns
         self.max_tool_iterations = max_tool_iterations
         self.citation_repair_timeout = citation_repair_timeout
+        self.enforce_citations = enforce_citations
         self.callbacks = callbacks or []
 
         # Load prompts
@@ -586,13 +591,33 @@ class ShallowResearcherAgent:
                 enable_logging=False,
             )
             generated_answer = sanitize_report(content).sanitized_report if content is not None else None
-            raise EmptySourceRegistryError(
-                "shallow research",
-                unavailable_tools=unavailable,
-                available_count=available_count,
-                reason=classify_empty_source_registry_reason(state.data_sources, available_count, unavailable),
-                generated_answer=generated_answer,
+            if self.enforce_citations or generated_answer is None:
+                raise EmptySourceRegistryError(
+                    "shallow research",
+                    unavailable_tools=unavailable,
+                    available_count=available_count,
+                    reason=classify_empty_source_registry_reason(state.data_sources, available_count, unavailable),
+                    generated_answer=generated_answer,
+                )
+
+            logger.info(
+                "Shallow research completed without captured sources; returning generated answer because "
+                "enforce_citations is false (available_tools=%d unavailable_tools=%d)",
+                available_count,
+                len(unavailable),
             )
+            content = generated_answer
+            if last_msg is not None:
+                for cb in self.callbacks:
+                    if hasattr(cb, "emit_final_report"):
+                        cb.emit_final_report(content, cited_urls=[])
+                        break
+
+                if hasattr(last_msg, "model_copy"):
+                    validated_result["messages"][-1] = last_msg.model_copy(update={"content": content})
+                else:
+                    validated_result["messages"][-1] = type(last_msg)(content=content)
+            return ShallowResearchAgentState.model_validate(validated_result)
 
         if validated_result.get("messages"):
             if content is not None:
@@ -611,7 +636,7 @@ class ShallowResearcherAgent:
                     citation_integrity = _has_citation_integrity(content, verification.valid_citations)
                     if not citation_integrity and len(sources) == 1:
                         content = _append_minimal_citation(content, sources[0])
-                    elif not citation_integrity:
+                    elif not citation_integrity and self.enforce_citations:
                         logger.info(
                             "Shallow report is missing citation integrity; attempting one bounded repair "
                             "(registered_sources=%d)",
@@ -627,6 +652,12 @@ class ShallowResearcherAgent:
                                 len(sources),
                                 len(repair_verification.valid_citations),
                             )
+                    elif not citation_integrity:
+                        logger.info(
+                            "Shallow report is missing citation integrity; returning generated answer because "
+                            "enforce_citations is false (registered_sources=%d)",
+                            len(sources),
+                        )
                 # Step 2: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
                 sanitization = sanitize_report(content)
                 content = sanitization.sanitized_report
@@ -641,7 +672,8 @@ class ShallowResearcherAgent:
                         len(registry.all_sources()),
                         len(final_verification.valid_citations),
                     )
-                    raise CitationIntegrityError()
+                    if self.enforce_citations:
+                        raise CitationIntegrityError()
                 content = _format_chat_references(final_verification.verified_report)
                 final_cited_urls = list(
                     dict.fromkeys(

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -74,6 +74,98 @@ _REFERENCE_TARGET_RE = re.compile(
     r"(?:https?://\S+|[^\s,]+\.\w{2,5}(?:,[^\n]+)?|[A-Za-z0-9]+(?:_+[A-Za-z0-9]+)+)$",
     re.IGNORECASE,
 )
+_EMERGENCY_SYNTHESIS_MAX_TOOL_RESULTS = 5
+_EMERGENCY_SYNTHESIS_TOOL_CHARS = 1200
+
+
+def _content_to_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _is_blank_response(response: Any) -> bool:
+    return not _content_to_text(getattr(response, "content", None)).strip()
+
+
+def _response_finish_reason(response: Any) -> str | None:
+    metadata = getattr(response, "response_metadata", None) or {}
+    if not isinstance(metadata, dict):
+        return None
+    finish_reason = metadata.get("finish_reason") or metadata.get("stop_reason")
+    return str(finish_reason) if finish_reason is not None else None
+
+
+def _response_reasoning_chars(response: Any) -> int:
+    additional_kwargs = getattr(response, "additional_kwargs", None) or {}
+    if not isinstance(additional_kwargs, dict):
+        return 0
+    return len(_content_to_text(additional_kwargs.get("reasoning_content")))
+
+
+def _truncate_evidence(text: str) -> str:
+    text = text.strip()
+    if len(text) <= _EMERGENCY_SYNTHESIS_TOOL_CHARS:
+        return text
+    return text[:_EMERGENCY_SYNTHESIS_TOOL_CHARS].rstrip() + "\n[truncated]"
+
+
+def _latest_human_question(messages: Sequence[Any]) -> str:
+    for message in reversed(messages):
+        if isinstance(message, HumanMessage):
+            question = _content_to_text(message.content).strip()
+            if question:
+                return question
+    return "No explicit user question was found in the conversation history."
+
+
+def _compact_tool_evidence(messages: Sequence[Any]) -> str:
+    evidence_blocks: list[str] = []
+    for index, message in enumerate(messages, start=1):
+        if not isinstance(message, ToolMessage):
+            continue
+        content = _content_to_text(message.content).strip()
+        if not content:
+            continue
+        tool_name = getattr(message, "name", None) or "tool"
+        evidence_blocks.append(f"Tool result {index} ({tool_name}):\n{_truncate_evidence(content)}")
+
+    if not evidence_blocks:
+        return "No non-empty tool evidence was returned."
+    return "\n\n".join(evidence_blocks[-_EMERGENCY_SYNTHESIS_MAX_TOOL_RESULTS:])
+
+
+def _build_emergency_synthesis_messages(messages: Sequence[Any]) -> list[Any]:
+    question = _latest_human_question(messages)
+    evidence = _compact_tool_evidence(messages)
+    system_message = SystemMessage(
+        content=(
+            "You are a final-answer synthesis pass. Return only the final answer in visible content. "
+            "Do not include reasoning. Do not call tools. Use only the provided question and compact evidence. "
+            "If the evidence is insufficient, say so directly."
+        )
+    )
+    user_message = HumanMessage(
+        content=(
+            f"Question:\n{question}\n\n"
+            f"Compact evidence from prior tool results:\n{evidence}\n\n"
+            "Return final answer only. Do not include reasoning. "
+            "When evidence is available, include inline [N] citations and a ## References section."
+        )
+    )
+    return [system_message, user_message]
 
 
 def _reference_entry_number(line: str, previous_number: int | None) -> int | None:
@@ -435,7 +527,19 @@ class ShallowResearcherAgent:
                     )
 
                     full_messages = [system_message] + processed_history + [synthesis_anchor]
-                    response = await self._get_llm().ainvoke(full_messages, config=draft_config)
+                    llm = self._get_llm()
+                    response = await llm.ainvoke(full_messages, config=draft_config)
+                    if _is_blank_response(response):
+                        logger.warning(
+                            "Forced synthesis returned empty content; retrying once with compact emergency synthesis "
+                            "(finish_reason=%s reasoning_chars=%d)",
+                            _response_finish_reason(response),
+                            _response_reasoning_chars(response),
+                        )
+                        response = await llm.ainvoke(
+                            _build_emergency_synthesis_messages(processed_history),
+                            config=draft_config,
+                        )
                     return {"messages": [response], "tool_iterations": iterations}
 
                 llm = self._get_llm()

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -79,6 +79,7 @@ _EMERGENCY_SYNTHESIS_TOOL_CHARS = 1200
 
 
 def _content_to_text(content: Any) -> str:
+    """Normalize LangChain message content variants into plain text."""
     if content is None:
         return ""
     if isinstance(content, str):
@@ -97,10 +98,12 @@ def _content_to_text(content: Any) -> str:
 
 
 def _is_blank_response(response: Any) -> bool:
+    """Return whether a model response has no visible answer content."""
     return not _content_to_text(getattr(response, "content", None)).strip()
 
 
 def _response_finish_reason(response: Any) -> str | None:
+    """Extract a provider finish reason for diagnostic logging."""
     metadata = getattr(response, "response_metadata", None) or {}
     if not isinstance(metadata, dict):
         return None
@@ -109,6 +112,7 @@ def _response_finish_reason(response: Any) -> str | None:
 
 
 def _response_reasoning_chars(response: Any) -> int:
+    """Return the hidden reasoning character count when the provider exposes it."""
     additional_kwargs = getattr(response, "additional_kwargs", None) or {}
     if not isinstance(additional_kwargs, dict):
         return 0
@@ -116,6 +120,7 @@ def _response_reasoning_chars(response: Any) -> int:
 
 
 def _truncate_evidence(text: str) -> str:
+    """Bound one tool result so the emergency retry stays small."""
     text = text.strip()
     if len(text) <= _EMERGENCY_SYNTHESIS_TOOL_CHARS:
         return text
@@ -123,6 +128,7 @@ def _truncate_evidence(text: str) -> str:
 
 
 def _latest_human_question(messages: Sequence[Any]) -> str:
+    """Recover the latest user question from the prior conversation history."""
     for message in reversed(messages):
         if isinstance(message, HumanMessage):
             question = _content_to_text(message.content).strip()
@@ -132,6 +138,7 @@ def _latest_human_question(messages: Sequence[Any]) -> str:
 
 
 def _compact_tool_evidence(messages: Sequence[Any]) -> str:
+    """Render the last few non-empty tool results as compact retry evidence."""
     evidence_blocks: list[str] = []
     for index, message in enumerate(messages, start=1):
         if not isinstance(message, ToolMessage):
@@ -148,8 +155,12 @@ def _compact_tool_evidence(messages: Sequence[Any]) -> str:
 
 
 def _build_emergency_synthesis_messages(messages: Sequence[Any]) -> list[Any]:
+    """Build a short, no-tools retry prompt for blank forced synthesis outputs."""
     question = _latest_human_question(messages)
     evidence = _compact_tool_evidence(messages)
+    # Keep only the original question and bounded evidence. Replaying the full
+    # history caused some reasoning models to spend the whole output budget on
+    # hidden reasoning and return empty visible content.
     system_message = SystemMessage(
         content=(
             "You are a final-answer synthesis pass. Return only the final answer in visible content. "
@@ -162,7 +173,9 @@ def _build_emergency_synthesis_messages(messages: Sequence[Any]) -> list[Any]:
             f"Question:\n{question}\n\n"
             f"Compact evidence from prior tool results:\n{evidence}\n\n"
             "Return final answer only. Do not include reasoning. "
-            "When evidence is available, include inline [N] citations and a ## References section."
+            "When evidence is available, include inline [N] citations and a final ## References section. "
+            "Every reference line must start exactly with '- [N]', for example '- [1] SOURCE.pdf, p.5'. "
+            "Do not use unnumbered reference bullets."
         )
     )
     return [system_message, user_message]
@@ -530,6 +543,8 @@ class ShallowResearcherAgent:
                     llm = self._get_llm()
                     response = await llm.ainvoke(full_messages, config=draft_config)
                     if _is_blank_response(response):
+                        # Retry once with a tiny prompt before returning a blank
+                        # response to the chat layer or standalone runner.
                         logger.warning(
                             "Forced synthesis returned empty content; retrying once with compact emergency synthesis "
                             "(finish_reason=%s reasoning_chars=%d)",

--- a/src/aiq_agent/agents/shallow_researcher/register.py
+++ b/src/aiq_agent/agents/shallow_researcher/register.py
@@ -59,6 +59,10 @@ class ShallowResearchAgentConfig(FunctionBaseConfig, name="shallow_research_agen
     )
     max_llm_turns: int = Field(default=10, description="Maximum number of LLM turns")
     max_tool_iterations: int = Field(default=5, description="Maximum tool-calling iterations before forcing synthesis")
+    enforce_citations: bool = Field(
+        default=False,
+        description="Fail instead of returning a generated answer when citation integrity cannot be preserved.",
+    )
     verbose: bool = Field(default=False, description="Whether to enable verbose logging")
 
 
@@ -178,6 +182,7 @@ async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Bu
                     tools=selected_tools,
                     max_llm_turns=config.max_llm_turns,
                     max_tool_iterations=config.max_tool_iterations,
+                    enforce_citations=config.enforce_citations,
                     callbacks=callbacks,
                 )
 

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -249,6 +249,37 @@ class TestChatResearcherAgent:
         assert result.get("workflow_outcome") is None
 
     @pytest.mark.asyncio
+    async def test_empty_shallow_response_escalates_to_deep_research(
+        self,
+        mock_intent_classifier,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """A blank shallow final answer should not terminate the chat turn."""
+
+        async def empty_shallow(state_input):
+            result = MagicMock()
+            result.messages = list(state_input.messages) + [AIMessage(content="")]
+            return result
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=mock_intent_classifier,
+            shallow_research_fn=empty_shallow,
+            deep_research_fn=mock_deep_research,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+            enable_escalation=True,
+        )
+
+        result = await agent.run(
+            ChatResearcherState(messages=[HumanMessage(content="What is CUDA?")]),
+            thread_id="test-empty-shallow-escalates",
+        )
+
+        assert result["messages"][-1].content == "Here's a comprehensive report."
+        assert result.get("workflow_outcome") is None
+
+    @pytest.mark.asyncio
     async def test_run_logs_query_metadata_without_customer_content(
         self,
         mock_intent_classifier,

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -110,6 +110,7 @@ class TestShallowResearcherAgent:
         assert agent.max_llm_turns == 10
         assert agent.max_tool_iterations == 5
         assert agent.citation_repair_timeout == 60.0
+        assert agent.enforce_citations is False
         assert agent.callbacks == []
         assert agent.system_prompt is not None
 
@@ -130,10 +131,12 @@ class TestShallowResearcherAgent:
             tools=[real_tool],
             max_llm_turns=5,
             max_tool_iterations=3,
+            enforce_citations=True,
         )
 
         assert agent.max_llm_turns == 5
         assert agent.max_tool_iterations == 3
+        assert agent.enforce_citations is True
 
     def test_init_with_callbacks(self, mock_llm_provider, real_tool):
         """Test ShallowResearcherAgent initialization with callbacks."""
@@ -611,6 +614,7 @@ class TestShallowResearcherSourceRegistryGating:
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[mcp_time__get_current_time],
+            enforce_citations=True,
         )
 
         state = ShallowResearchAgentState(messages=[HumanMessage(content="What time is it in Tokyo?")])
@@ -718,6 +722,7 @@ class TestShallowResearcherSourceRegistryGating:
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[knowledge_search],
+            enforce_citations=True,
             callbacks=[callback],
         )
 
@@ -816,6 +821,7 @@ class TestShallowResearcherSourceRegistryGating:
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[mcp_time__get_current_time, web_search_with_urls],
+            enforce_citations=True,
             callbacks=[callback],
         )
 
@@ -838,6 +844,58 @@ class TestShallowResearcherSourceRegistryGating:
         repair_call = mock_llm.ainvoke.await_args
         assert repair_call.kwargs["config"]["tags"] == [SUPPRESS_OUTPUT_ARTIFACT_TAG]
         assert isinstance(repair_call.args[0][0], SystemMessage)
+
+    @pytest.mark.asyncio
+    async def test_default_multi_source_citation_integrity_failure_returns_draft(self, mock_llm_provider, mock_llm):
+        """Default citation mode returns the answer without running the strict repair pass."""
+        populate_from_config(
+            [
+                {
+                    "id": "mcp_time",
+                    "name": "MCP Time",
+                    "description": "Get current time and timezone information through MCP.",
+                    "tools": ["mcp_time"],
+                },
+                {
+                    "id": "web_search",
+                    "name": "Web Search",
+                    "description": "Search the web for real-time information.",
+                    "tools": ["web_search_with_urls"],
+                },
+            ],
+            group_names={"mcp_time"},
+        )
+        tool_call_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "mcp_time__get_current_time", "args": {"timezone": "Asia/Tokyo"}, "id": "1"},
+                {"name": "web_search_with_urls", "args": {"query": "CUDA"}, "id": "2"},
+            ],
+        )
+        source_only_draft = AIMessage(
+            content=(
+                "CUDA is a parallel computing platform.\n\n"
+                "**References:**\n- [1] CUDA Toolkit Documentation - https://docs.nvidia.com/cuda/"
+            )
+        )
+        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, source_only_draft])
+        callback = MagicMock()
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[mcp_time__get_current_time, web_search_with_urls],
+            callbacks=[callback],
+        )
+
+        result = await agent.run(
+            ShallowResearchAgentState(messages=[HumanMessage(content="What is CUDA? Also note the time.")])
+        )
+
+        assert "CUDA is a parallel computing platform." in result.messages[-1].content
+        assert mock_llm.ainvoke.await_count == 2
+        callback.emit_final_report.assert_called_once_with(
+            result.messages[-1].content,
+            cited_urls=["https://docs.nvidia.com/cuda/"],
+        )
 
     @pytest.mark.asyncio
     async def test_failed_multi_source_repair_is_not_published(self, mock_llm_provider, mock_llm):
@@ -877,6 +935,7 @@ class TestShallowResearcherSourceRegistryGating:
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[mcp_time__get_current_time, web_search_with_urls],
+            enforce_citations=True,
             callbacks=[callback],
         )
 
@@ -1052,6 +1111,7 @@ class TestShallowResearcherSourceCaptureIntegration:
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[web_search_with_urls],
+            enforce_citations=True,
             callbacks=[callback],
         )
 
@@ -1173,6 +1233,7 @@ class TestShallowResearcherSessionRegistry:
         agent = ShallowResearcherAgent(
             llm_provider=mock_llm_provider,
             tools=[],
+            enforce_citations=True,
         )
         # Pre-populate the instance registry (simulating stale data)
         agent.source_registry.add(SourceEntry(url="https://stale.example.com"))
@@ -1181,6 +1242,20 @@ class TestShallowResearcherSessionRegistry:
 
         with pytest.raises(EmptySourceRegistryError):
             await agent.run(state)
+
+    @pytest.mark.asyncio
+    async def test_default_empty_registry_returns_sanitized_answer(self, mock_llm_provider, mock_llm):
+        """By default, citation-source failures return the generated answer instead of raising."""
+        from aiq_agent.common.citation_verification import set_session_registry
+
+        set_session_registry(None)
+        mock_llm.ainvoke = AsyncMock(return_value=AIMessage(content="Draft answer with https://private.example/path"))
+        agent = ShallowResearcherAgent(llm_provider=mock_llm_provider, tools=[])
+        state = ShallowResearchAgentState(messages=[HumanMessage(content="Test")])
+
+        result = await agent.run(state)
+
+        assert result.messages[-1].content == "Draft answer with "
 
     @pytest.mark.parametrize(
         ("data_sources", "expected_reason"),
@@ -1199,7 +1274,7 @@ class TestShallowResearcherSessionRegistry:
         expected_reason,
     ):
         mock_llm.ainvoke = AsyncMock(return_value=AIMessage(content="Draft answer with https://private.example/path"))
-        agent = ShallowResearcherAgent(llm_provider=mock_llm_provider, tools=[])
+        agent = ShallowResearcherAgent(llm_provider=mock_llm_provider, tools=[], enforce_citations=True)
         state = ShallowResearchAgentState(
             messages=[HumanMessage(content="Test")],
             data_sources=data_sources,
@@ -1235,7 +1310,11 @@ class TestShallowResearcherSessionRegistry:
         )
         generated_answer = "No supporting sources were found, so I cannot provide a sourced answer."
         mock_llm.ainvoke = AsyncMock(side_effect=[tool_call, AIMessage(content=generated_answer)])
-        agent = ShallowResearcherAgent(llm_provider=mock_llm_provider, tools=[empty_web_search_tool])
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[empty_web_search_tool],
+            enforce_citations=True,
+        )
         state = ShallowResearchAgentState(
             messages=[HumanMessage(content="Summarize quantum computing.")],
             data_sources=["web"],

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -26,6 +26,7 @@ import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import SystemMessage
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 
 from aiq_agent.agents.shallow_researcher.agent import ShallowResearcherAgent
@@ -529,6 +530,64 @@ class TestShallowResearcherAgent:
         )
         assert synthesis_instruction_found
         assert captured_configs == [{"tags": [SUPPRESS_OUTPUT_ARTIFACT_TAG]}]
+
+    @pytest.mark.asyncio
+    async def test_forced_synthesis_retries_empty_length_response(self, mock_llm_provider, mock_llm, real_tool):
+        """Blank forced synthesis responses get one compact retry before returning."""
+        empty_length_response = AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "thinking until the output budget is exhausted"},
+            response_metadata={"finish_reason": "length"},
+        )
+        retry_response = AIMessage(
+            content=(
+                "The actual growth exceeded the expected growth by 1.5 percentage points [1].\n\n"
+                "## References\n[1] JOHNSON_JOHNSON_2023Q2_EARNINGS.pdf, p.5"
+            )
+        )
+        captured_messages = []
+
+        async def capture_messages(messages, *, config):
+            assert config == {"tags": [SUPPRESS_OUTPUT_ARTIFACT_TAG]}
+            captured_messages.append(messages)
+            return empty_length_response if len(captured_messages) == 1 else retry_response
+
+        mock_llm.ainvoke = AsyncMock(side_effect=capture_messages)
+
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[real_tool],
+            max_tool_iterations=1,
+        )
+        state = ShallowResearchAgentState(
+            messages=[
+                HumanMessage(content="By how many percentage points did EPS growth differ?"),
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "web_search_tool", "args": {"query": "JNJ EPS"}, "id": "call-1"}],
+                ),
+                ToolMessage(
+                    content="Adjusted EPS growth midpoint was 5.0%; prior guidance expected 3.5%.",
+                    name="web_search_tool",
+                    tool_call_id="call-1",
+                ),
+            ],
+            tool_iterations=1,
+        )
+
+        result = await agent.run(state)
+
+        assert result.messages[-1].content == retry_response.content
+        assert mock_llm.ainvoke.await_count == 2
+
+        retry_messages = captured_messages[1]
+        assert len(retry_messages) == 2
+        assert isinstance(retry_messages[0], SystemMessage)
+        assert isinstance(retry_messages[1], HumanMessage)
+        assert all(not isinstance(message, ToolMessage) for message in retry_messages)
+        assert "Return final answer only" in retry_messages[1].content
+        assert "By how many percentage points did EPS growth differ?" in retry_messages[1].content
+        assert "Adjusted EPS growth midpoint was 5.0%" in retry_messages[1].content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -958,6 +958,126 @@ class TestShallowResearcherSourceRegistryGating:
         )
 
     @pytest.mark.asyncio
+    async def test_default_emergency_synthesis_citation_integrity_failure_returns_draft(
+        self, mock_llm_provider, mock_llm
+    ):
+        """Emergency synthesis still returns the draft when citation enforcement is disabled."""
+        populate_from_config(
+            [
+                {
+                    "id": "mcp_time",
+                    "name": "MCP Time",
+                    "description": "Get current time and timezone information through MCP.",
+                    "tools": ["mcp_time"],
+                },
+                {
+                    "id": "web_search",
+                    "name": "Web Search",
+                    "description": "Search the web for real-time information.",
+                    "tools": ["web_search_with_urls"],
+                },
+            ],
+            group_names={"mcp_time"},
+        )
+        tool_call_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "mcp_time__get_current_time", "args": {"timezone": "Asia/Tokyo"}, "id": "1"},
+                {"name": "web_search_with_urls", "args": {"query": "CUDA"}, "id": "2"},
+            ],
+        )
+        blank_forced_synthesis = AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "The model spent its budget on hidden reasoning."},
+            response_metadata={"finish_reason": "length"},
+        )
+        source_only_draft = AIMessage(
+            content=(
+                "CUDA is a parallel computing platform.\n\n"
+                "**References:**\n- [1] CUDA Toolkit Documentation - https://docs.nvidia.com/cuda/"
+            )
+        )
+        mock_llm.ainvoke = AsyncMock(side_effect=[tool_call_response, blank_forced_synthesis, source_only_draft])
+        callback = MagicMock()
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[mcp_time__get_current_time, web_search_with_urls],
+            max_tool_iterations=1,
+            callbacks=[callback],
+        )
+
+        result = await agent.run(
+            ShallowResearchAgentState(messages=[HumanMessage(content="What is CUDA? Also note the time.")])
+        )
+
+        assert "CUDA is a parallel computing platform." in result.messages[-1].content
+        assert mock_llm.ainvoke.await_count == 3
+        callback.emit_final_report.assert_called_once_with(
+            result.messages[-1].content,
+            cited_urls=["https://docs.nvidia.com/cuda/"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_enforced_emergency_synthesis_citation_integrity_failure_raises(self, mock_llm_provider, mock_llm):
+        """Strict citation mode fails closed when the emergency fallback cannot restore integrity."""
+        populate_from_config(
+            [
+                {
+                    "id": "mcp_time",
+                    "name": "MCP Time",
+                    "description": "Get current time and timezone information through MCP.",
+                    "tools": ["mcp_time"],
+                },
+                {
+                    "id": "web_search",
+                    "name": "Web Search",
+                    "description": "Search the web for real-time information.",
+                    "tools": ["web_search_with_urls"],
+                },
+            ],
+            group_names={"mcp_time"},
+        )
+        tool_call_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "mcp_time__get_current_time", "args": {"timezone": "Asia/Tokyo"}, "id": "1"},
+                {"name": "web_search_with_urls", "args": {"query": "CUDA"}, "id": "2"},
+            ],
+        )
+        blank_forced_synthesis = AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "The model spent its budget on hidden reasoning."},
+            response_metadata={"finish_reason": "length"},
+        )
+        source_only_draft = AIMessage(
+            content=(
+                "CUDA is a parallel computing platform.\n\n"
+                "**References:**\n- [1] CUDA Toolkit Documentation - https://docs.nvidia.com/cuda/"
+            )
+        )
+        mock_llm.ainvoke = AsyncMock(
+            side_effect=[tool_call_response, blank_forced_synthesis, source_only_draft, source_only_draft]
+        )
+        callback = MagicMock()
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[mcp_time__get_current_time, web_search_with_urls],
+            max_tool_iterations=1,
+            enforce_citations=True,
+            callbacks=[callback],
+        )
+
+        with pytest.raises(CitationIntegrityError, match="citation_integrity_lost"):
+            await agent.run(
+                ShallowResearchAgentState(messages=[HumanMessage(content="What is CUDA? Also note the time.")])
+            )
+
+        assert mock_llm.ainvoke.await_count == 4
+        for invocation in mock_llm.ainvoke.await_args_list[1:]:
+            assert invocation.kwargs["config"]["tags"] == [SUPPRESS_OUTPUT_ARTIFACT_TAG]
+        callback.emit_final_report.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_failed_multi_source_repair_is_not_published(self, mock_llm_provider, mock_llm):
         """A single unsuccessful repair fails closed without emitting an uncited report."""
         populate_from_config(

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -586,6 +586,7 @@ class TestShallowResearcherAgent:
         assert isinstance(retry_messages[1], HumanMessage)
         assert all(not isinstance(message, ToolMessage) for message in retry_messages)
         assert "Return final answer only" in retry_messages[1].content
+        assert "Every reference line must start exactly with '- [N]'" in retry_messages[1].content
         assert "By how many percentage points did EPS growth differ?" in retry_messages[1].content
         assert "Adjusted EPS growth midpoint was 5.0%" in retry_messages[1].content
 

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -2923,6 +2923,50 @@ class TestAsyncJobRunnerAgentFactory:
         assert agent.resource_limits is fn_config.resource_limits
         assert agent.resource_limits.max_source_tool_calls == 8
 
+    def test_create_agent_instance_passes_shallow_research_config(self):
+        """Async workers pass shallow citation enforcement through the constructor."""
+        from aiq_agent.agents.shallow_researcher.register import ShallowResearchAgentConfig
+        from aiq_api.jobs.runner import _create_agent_instance
+
+        class FakeShallowResearcherAgent:
+            def __init__(
+                self,
+                *,
+                llm_provider,
+                tools,
+                max_tool_iterations=5,
+                enforce_citations=False,
+                callbacks=None,
+            ):
+                self.llm_provider = llm_provider
+                self.tools = tools
+                self.max_tool_iterations = max_tool_iterations
+                self.enforce_citations = enforce_citations
+                self.callbacks = callbacks
+
+        assert ShallowResearchAgentConfig(llm="llm").enforce_citations is False
+        fn_config = ShallowResearchAgentConfig(
+            llm="llm",
+            max_tool_iterations=2,
+            enforce_citations=True,
+        )
+
+        agent = _create_agent_instance(
+            agent_cls=FakeShallowResearcherAgent,
+            llm_provider="provider",
+            llm="llm",
+            tools=["tool"],
+            fn_config=fn_config,
+            verbose=False,
+            callbacks=["callback"],
+        )
+
+        assert agent.llm_provider == "provider"
+        assert agent.tools == ["tool"]
+        assert agent.max_tool_iterations == 2
+        assert agent.enforce_citations is True
+        assert agent.callbacks == ["callback"]
+
     def test_create_agent_instance_allows_non_deep_agent_to_reuse_deep_config(self):
         """Async workers should not treat shared DeepResearchAgentConfig as a constructor contract."""
         from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig


### PR DESCRIPTION
#### Overview

Fixes empty shallow research responses when the model reaches `max_tool_iterations`.

Root cause: the endpoint was not throwing an exception. In the failing runs, the model returned an `AIMessage` with empty visible `content`, `finish_reason="length"`, and `completion_tokens=8192`. The response also contained a large hidden `reasoning_content` payload. In simple terms, the model used the available output budget on hidden reasoning and hit the 8192-token completion limit before producing any visible final answer.

This happened in the forced-synthesis path after the shallow researcher exhausted its tool iteration budget. At that point we were sending the full conversation and tool history back to the model and asking it to synthesize the final answer. For reasoning-heavy models, that large prompt could cause the model to spend too much output budget reasoning internally, resulting in a blank visible answer.

The fix adds one emergency retry before returning/escalating an empty shallow response. If forced synthesis returns blank visible content, shallow research retries once with a compact synthesis prompt: no tools, no full history, only the latest user question plus compact tool evidence. If that retry still returns blank visible content, the chat researcher treats shallow research as unsuccessful and escalates to the deep research agent, assuming deep research is enabled.

The compact retry keeps at most the last 5 non-empty tool results and truncates each tool result to 1200 characters. The prompt explicitly tells the model to return final answer only, not include reasoning, not call tools, use only the provided question and evidence, say when evidence is insufficient, include inline `[N]` citations when evidence exists, and include a final `## References` section where every reference line starts exactly with `- [N]`.

If existing forced synthesis after max tool limit is reached, returns blank visible content, shallow research retries once with:

- no tools
- only the latest original user question
- only compact evidence from prior tool results
- at most the last 5 non-empty tool results
- each tool result truncated to 1200 characters
- no full conversation replay

The emergency retry prompt explicitly tells the model:

- return final answer only
- do not include reasoning
- do not call tools
- use only the provided question and compact evidence
- if evidence is insufficient, say so directly
- include inline `[N]` citations when evidence exists
- include a final `## References` section
- every reference line must start exactly as `- [N]`
- do not use unnumbered reference bullets


#### DCO sign-off for the squash commit

<!--
The RAPIDS auto-merger copies this PR description into the generated squash
commit. GitHub may author that commit with a different email than your local
commits. Replace the placeholder below with the exact commit email configured
for your GitHub account. If you keep your email private, copy the
`@users.noreply.github.com` address shown at https://github.com/settings/emails.

If your local/work email differs from your GitHub commit email, you may include
both sign-offs. DCO passes when one sign-off exactly matches the generated
squash commit author:

Signed-off-by: Full Name <work.email@example.com>
Signed-off-by: Full Name <github-email@users.noreply.github.com>

Keep the angle brackets around the email address. They are part of the required
DCO format: `Signed-off-by: Full Name <email@example.com>`.

Do not delete the sign-off line, leave the placeholder unchanged, or remove the
angle brackets.
-->

Signed-off-by: Shubhadeep Das <shubhadeepd@nvidia.com>

#### Validation

```bash
UV_CACHE_DIR=/tmp/aiq-fork-uv-cache uv run --extra dev pytest tests/aiq_agent/agents/shallow_researcher/test_agent.py
UV_CACHE_DIR=/tmp/aiq-fork-uv-cache uv run --extra dev pytest tests/aiq_agent/agents/chat_researcher/test_agent.py -k "empty_shallow_response_escalates_to_deep_research or shallow_research_flow"
UV_CACHE_DIR=/tmp/aiq-fork-uv-cache uv run --extra dev ruff check tests/aiq_agent/agents/shallow_researcher/test_agent.py src/aiq_agent/agents/shallow_researcher/agent.py src/aiq_agent/agents/chat_researcher/agent.py tests/aiq_agent/agents/chat_researcher/test_agent.py
UV_CACHE_DIR=/tmp/aiq-fork-uv-cache uv run --extra dev ruff format --check tests/aiq_agent/agents/shallow_researcher/test_agent.py src/aiq_agent/agents/shallow_researcher/agent.py src/aiq_agent/agents/chat_researcher/agent.py tests/aiq_agent/agents/chat_researcher/test_agent.py
```
- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with src/aiq_agent/agents/shallow_researcher/agent.py, specifically the max-tool-iteration forced synthesis path and emergency retry.
Then review the regression tests in tests/aiq_agent/agents/shallow_researcher/test_agent.py covering citation behavior for the emergency fallback with enforce_citations both disabled and enabled.

#### Related Issues

Fixes https://jirasw.nvidia.com/browse/AIQ-3774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable citation enforcement for shallow research.
  * By default, citation issues return a sanitized answer; strict mode reports an error instead.
  * Added a bounded retry for blank synthesized responses.
  * Empty research responses can now escalate to deeper research when enabled.

* **Bug Fixes**
  * Improved handling of blank and whitespace-only responses.
  * Preserved response metadata and safer handling of missing source content.

* **Documentation**
  * Updated configuration examples and guidance for citation-backed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->