### PR TITLE
fix: raise Lightning shallow output cap

### DIFF
--- a/.agents/skills/aiq-configure-workflow/assets/config-scaffold.yml
+++ b/.agents/skills/aiq-configure-workflow/assets/config-scaffold.yml
@@ -37,7 +37,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_cli_default.yml
+++ b/configs/config_cli_default.yml
@@ -34,7 +34,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_mcp.yml
+++ b/configs/config_mcp.yml
@@ -48,7 +48,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_openshell.yml
+++ b/configs/config_openshell.yml
@@ -50,7 +50,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_web_azure_ai_search.yml
+++ b/configs/config_web_azure_ai_search.yml
@@ -65,7 +65,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_web_default_guardrails.yml
+++ b/configs/config_web_default_guardrails.yml
@@ -50,7 +50,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -63,7 +63,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_web_frag.yml
+++ b/configs/config_web_frag.yml
@@ -67,7 +67,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_web_frag_mcp_auth.yml
+++ b/configs/config_web_frag_mcp_auth.yml
@@ -74,7 +74,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/config_web_opensearch.yml
+++ b/configs/config_web_opensearch.yml
@@ -66,7 +66,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/configs/nemo_relay/config_web_default_with_pricing.yml
+++ b/configs/nemo_relay/config_web_default_with_pricing.yml
@@ -65,7 +65,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_LIGHTNING_AGENT_MAX_TOKENS = 32768
+CONFIG_PATHS = [
+    REPO_ROOT / "configs" / "config_cli_default.yml",
+    REPO_ROOT / "configs" / "config_mcp.yml",
+    REPO_ROOT / "configs" / "config_openshell.yml",
+    REPO_ROOT / "configs" / "config_web_azure_ai_search.yml",
+    REPO_ROOT / "configs" / "config_web_default_guardrails.yml",
+    REPO_ROOT / "configs" / "config_web_default_llamaindex.yml",
+    REPO_ROOT / "configs" / "config_web_frag.yml",
+    REPO_ROOT / "configs" / "config_web_frag_mcp_auth.yml",
+    REPO_ROOT / "configs" / "config_web_opensearch.yml",
+    REPO_ROOT / "configs" / "nemo_relay" / "config_web_default_with_pricing.yml",
+    REPO_ROOT / ".agents" / "skills" / "aiq-configure-workflow" / "assets" / "config-scaffold.yml",
+]
+
+
+@pytest.mark.parametrize("config_path", CONFIG_PATHS, ids=lambda path: str(path.relative_to(REPO_ROOT)))
+def test_lightning_agent_llm_uses_full_output_cap(config_path: Path) -> None:
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    lightning_agent_llm = config["llms"]["nemotron_lightning_agent_llm"]
+
+    assert lightning_agent_llm.get("max_tokens") == EXPECTED_LIGHTNING_AGENT_MAX_TOKENS


### PR DESCRIPTION
#### Overview

Raises the shallow Lightning agent output cap from `8192` to `32768` across the AIQ configs and workflow scaffold that define `nemotron_lightning_agent_llm`.

Root cause: the shallow Lightning model has reasoning enabled, and the model's default reasoning budget is larger than the old visible output cap. When the shallow agent reached `max_tool_iterations`, AIQ asked the model to synthesize a final answer from the gathered evidence. Some responses spent enough tokens on hidden reasoning that the `8192` cap could be exhausted before a visible final answer was emitted, producing an empty response even though the tool loop had collected evidence.

Fix: set `nemotron_lightning_agent_llm.max_tokens` to the model-supported maximum of `32768` in all shipped shallow Lightning agent configs. This gives the final synthesis path enough room for both hidden reasoning and the visible answer without changing the agent runtime behavior.

Updated configs:

- `configs/config_cli_default.yml`
- `configs/config_mcp.yml`
- `configs/config_openshell.yml`
- `configs/config_web_azure_ai_search.yml`
- `configs/config_web_default_guardrails.yml`
- `configs/config_web_default_llamaindex.yml`
- `configs/config_web_frag.yml`
- `configs/config_web_frag_mcp_auth.yml`
- `configs/config_web_opensearch.yml`
- `configs/nemo_relay/config_web_default_with_pricing.yml`
- `.agents/skills/aiq-configure-workflow/assets/config-scaffold.yml`

Note: two config blocks are named `nemotron_lightning_agent_llm` but currently point at the Ultra model. Those blocks were updated too so every shallow agent config using that LLM slot has the same cap.

#### DCO sign-off for the squash commit

Signed-off-by: Shubhadeep Das <shubhadeepd@nvidia.com>

#### Validation

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

Validation performed:

- `git diff --check HEAD~1 HEAD`
- Parsed all `configs/**/*.yml` files with PyYAML.
- Audited every `nemotron_lightning_agent_llm` block in shipped configs and the reusable scaffold, and confirmed `max_tokens: 32768`.
- `UV_CACHE_DIR=/tmp/aiq-uv-cache uv run --extra dev pytest tests/test_config_defaults.py`
- `./.venv/bin/ruff check tests/test_config_defaults.py`
- `./.venv/bin/ruff format --check tests/test_config_defaults.py`
- `./.venv/bin/python -m pytest tests/test_config_defaults.py`
- Confirmed the commit is GPG-signed and includes `Signed-off-by: Shubhadeep Das <shubhadeepd@nvidia.com>`.
- Manual Harbor repro validation: six historical empty-response FinanceBench tasks produced non-empty answer artifacts with the 32,768-token shallow Lightning cap. Harbor scoring was not used for answer quality because the grader returned malformed/empty grading output.

Documentation was not updated because the visible user-facing behavior and configuration schema are unchanged.

#### Where should reviewers start?

Start with `configs/config_web_frag.yml`; the same `nemotron_lightning_agent_llm.max_tokens` update is then applied consistently to the other shipped config variants.

#### Related Issues

- Relates to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased the maximum generated response length from 8,192 to 32,768 tokens across supported CLI, web, search, MCP, RAG, and workflow configurations.
  - Enables substantially longer responses for tasks requiring extensive detail or context.
- **Tests**
  - Added validation to ensure supported configurations consistently use the updated response-length limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->