### PR TITLE
fix(security): update pip past CVE-2026-13346

### DIFF
--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -4189,11 +4189,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

Updates the MCP production lock from pip 26.1.2 to 26.2.1. This resolves PYSEC-2026-3721 / CVE-2026-13346, which currently fails the `Gate production dependency lock` step on `develop` and on PR #416.

## Validation

- `uvx --from uv==0.11.26 uv audit --preview-features audit-command,json-output --project mcp --frozen --no-dev --no-default-groups --ignore-until-fixed GHSA-f4j7-r4q5-qw2c --output-format json` — 309 packages audited, 0 vulnerabilities

## Contributor checklist

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added only the lockfile change required to resolve the production dependency gate.
- [x] I confirm this PR contains no secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed the commit with `git commit -s`.