### PR TITLE
feat: run the data science agent as an async job

### DIFF
--- a/configs/config_web_data_science.yml
+++ b/configs/config_web_data_science.yml
@@ -61,7 +61,10 @@ function_groups:
     auth:
       mode: password
       email: ${GSF_EMAIL}
-      password: ${GSF_PASSWORD}
+      # This field takes the NAME of the env var holding the password, not the
+      # password itself. Using ${GSF_PASSWORD} here resolves to the secret and
+      # GSF then looks up an env var by that value, silently disabling the tools.
+      password: GSF_PASSWORD  # pragma: allowlist secret
     include:
       - catalog_search
       - text_to_sql

--- a/configs/config_web_data_science.yml
+++ b/configs/config_web_data_science.yml
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Web profile for the Data Science Agent, served as an async job.
+#
+# A DS run can take several minutes, so the agent is submitted to the async job
+# API instead of being held open on a request. Clients POST
+# /v1/jobs/async/submit with agent_type "data_science", then stream progress
+# from /v1/jobs/async/job/{job_id}/stream. Closing or refreshing the browser
+# does not cancel the run: reconnecting to the same job_id replays the stored
+# events and returns the final report.
+#
+# Async jobs run in a Dask worker that reloads this file, so NAT_CONFIG_FILE
+# must point at it and NAT_DASK_SCHEDULER_ADDRESS must be set.
+#
+# Required: INFERENCE_NVIDIA_API_KEY, AIQ_INFERENCE_BASE_URL,
+# AIQ_DATA_SCIENCE_MODEL, TAVILY_API_KEY, GSF_BASE_URL, GSF_EMAIL,
+# GSF_PASSWORD, RAG_SERVER_URL, COLLECTION_NAME.
+
+general:
+  use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: INFO
+
+  front_end:
+    _type: aiq_api
+    runner_class: aiq_api.plugin.AIQAPIWorker
+    db_url: ${NAT_JOB_STORE_DB_URL:-sqlite+aiosqlite:///./jobs.db}
+    expiry_seconds: 86400  # 24 hours (min: 600, max: 604800/7 days)
+    cors:
+      allow_origin_regex: 'http://localhost(:\d+)?|http://127.0.0.1(:\d+)?'
+      allow_methods:
+        - GET
+        - POST
+        - DELETE
+        - OPTIONS
+      allow_headers:
+        - "*"
+      allow_credentials: true
+      expose_headers:
+        - "*"
+
+llms:
+  data_science_llm:
+    _type: openai
+    model_name: ${AIQ_DATA_SCIENCE_MODEL}
+    base_url: ${AIQ_INFERENCE_BASE_URL}
+    api_key: ${INFERENCE_NVIDIA_API_KEY}
+    reasoning_effort: medium
+    max_tokens: 32768
+    num_retries: 2
+    request_timeout: 600
+
+function_groups:
+  gsf:
+    _type: gsf
+    base_url: ${GSF_BASE_URL}
+    auth:
+      mode: password
+      email: ${GSF_EMAIL}
+      password: ${GSF_PASSWORD}
+    include:
+      - catalog_search
+      - text_to_sql
+    connect_timeout_seconds: 10
+    read_timeout_seconds: ${GSF_READ_TIMEOUT_SECONDS:-600}
+    max_retries: 2
+    default_max_rows: 1000
+
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: structured_data
+        name: "Enterprise Structured Data"
+        description: "Discover enterprise semantics and execute bounded analytical queries through GSF."
+        tools:
+          - gsf
+      - id: knowledge_base
+        name: "Knowledge Base"
+        description: "Search the configured document collection for relevant unstructured evidence."
+        tools:
+          - knowledge_search
+      - id: web_search
+        name: "Web Search"
+        description: "Search the public web for current and external information."
+        tools:
+          - web_search_tool
+
+  knowledge_search:
+    _type: knowledge_retrieval
+    backend: foundational_rag
+    collection_name: ${COLLECTION_NAME}
+    top_k: 5
+    rag_url: ${RAG_SERVER_URL}
+    # This profile is retrieval-only; fail closed if an ingestion path is invoked.
+    ingest_url: http://127.0.0.1:9/v1
+    timeout: ${RAG_RETRIEVAL_TIMEOUT_SECONDS:-300}
+    summary_db: ${AIQ_SUMMARY_DB:-sqlite+aiosqlite:////tmp/aiq-ds-summaries.db}
+    # Keep certificate verification enabled by default; trusted test routes with a
+    # self-signed chain can opt out locally with RAG_VERIFY_SSL=false.
+    verify_ssl: ${RAG_VERIFY_SSL:-true}
+
+  web_search_tool:
+    _type: tavily_web_search
+    max_results: 5
+    advanced_search: true
+    max_content_length: 2000
+
+  data_science_agent:
+    _type: data_science_agent
+    llm: data_science_llm
+    # tools omitted: inherit GSF, knowledge, and web tools from data_sources
+    # An async job has no channel back to the user, so the job runner always
+    # runs this agent headless regardless of the value set here. Leave it
+    # interactive only if the same config also serves a synchronous CLI run.
+    interaction_mode: ${AIQ_DS_INTERACTION_MODE:-headless}
+    recursion_limit: 64
+    verbose: true
+
+workflow:
+  _type: data_science_workflow

--- a/configs/config_web_data_science_hybrid.yml
+++ b/configs/config_web_data_science_hybrid.yml
@@ -1,0 +1,299 @@
+# Web profile that routes structured-data questions to the Data Science Agent.
+#
+# The chat router (context_aware_intent_router) probes the GSF catalog on each
+# research request. When coverage clears catalog_confidence_threshold -- or the
+# request carries an explicit database_name scope -- it takes the Hybrid path and
+# submits the DS agent as an async job, so the run survives a browser refresh.
+#
+# Requires: NVIDIA_API_KEY, TAVILY_API_KEY, GSF_BASE_URL, GSF_EMAIL, GSF_PASSWORD.
+# Async jobs reload this file in a worker, so NAT_CONFIG_FILE must point at it.
+
+
+general:
+  use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: INFO
+
+  front_end:
+    _type: aiq_api
+    runner_class: aiq_api.plugin.AIQAPIWorker
+    # =========================================================================
+    # Knowledge API is automatically enabled when knowledge_retrieval function
+    # is configured
+    # =========================================================================
+    # Async Job API Settings
+    # =========================================================================
+    # Async job infrastructure database (NAT JobStore + EventStore)
+    # Used by: /v1/jobs/async routes, SSE streaming, job status persistence
+    # Requires async driver for SQLite (aiosqlite) or PostgreSQL (asyncpg)
+    # Environment overrides:
+    # - NAT_JOB_STORE_DB_URL (direct override)
+    # - NAT_JOB_STORE_DB_URL_DEV / NAT_JOB_STORE_DB_URL_PROD (via NAT_ENV)
+    db_url: ${NAT_JOB_STORE_DB_URL:-sqlite+aiosqlite:///./jobs.db}
+    # Job expiry - how long completed jobs stay in database before cleanup
+    expiry_seconds: 86400  # 24 hours (min: 600, max: 604800/7 days)
+    cors:
+      allow_origin_regex: 'http://localhost(:\d+)?|http://127.0.0.1(:\d+)?'
+      allow_methods:
+        - GET
+        - POST
+        - DELETE
+        - OPTIONS
+      allow_headers:
+        - "*"
+      allow_credentials: true
+      expose_headers:
+        - "*"
+
+llms:
+  nemotron_lightning_intent_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3.5-lightning-30b-a3b
+    base_url: "https://integrate.api.nvidia.com/v1"
+    api_key: ${NVIDIA_API_KEY}
+    temperature: 0.1
+    top_p: 0.9
+    max_tokens: 1024
+    num_retries: 5
+    parallel_tool_calls: false
+    chat_template_kwargs:
+      enable_thinking: false
+
+  nemotron_lightning_agent_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-ultra-550b-a55b
+    base_url: "https://integrate.api.nvidia.com/v1"
+    api_key: ${NVIDIA_API_KEY}
+    temperature: 0.2
+    top_p: 0.7
+    max_tokens: 32768
+    num_retries: 5
+    parallel_tool_calls: false
+    chat_template_kwargs:
+      enable_thinking: true
+
+  nemotron_ultra_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-ultra-550b-a55b
+    base_url: "https://integrate.api.nvidia.com/v1"
+    api_key: ${NVIDIA_API_KEY}
+    temperature: 0.2
+    top_p: 0.7
+    max_tokens: 16384
+    num_retries: 5
+    chat_template_kwargs:
+      enable_thinking: false
+
+  nemotron_ultra_writer_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-ultra-550b-a55b
+    base_url: "https://integrate.api.nvidia.com/v1"
+    api_key: ${NVIDIA_API_KEY}
+    temperature: 0.2
+    top_p: 0.7
+    max_tokens: 32768
+    num_retries: 5
+    chat_template_kwargs:
+      enable_thinking: false
+
+  # LLM for document summaries (required when generate_summary: true)
+  summary_llm:
+    _type: nim
+    model_name: google/gemma-4-31b-it
+    base_url: "https://integrate.api.nvidia.com/v1"
+    api_key: ${NVIDIA_API_KEY}
+    temperature: 0.1
+    max_tokens: 100
+
+function_groups:
+  gsf:
+    _type: gsf
+    base_url: ${GSF_BASE_URL}
+    auth:
+      mode: password
+      email: ${GSF_EMAIL}
+      # This field takes the NAME of the env var holding the password, not the
+      # password itself. Using ${GSF_PASSWORD} here resolves to the secret and
+      # GSF then looks up an env var by that value, silently disabling the tools.
+      password: GSF_PASSWORD  # pragma: allowlist secret
+    include:
+      - catalog_search
+      - text_to_sql
+    connect_timeout_seconds: 10
+    read_timeout_seconds: ${GSF_READ_TIMEOUT_SECONDS:-600}
+    max_retries: 2
+    default_max_rows: 1000
+
+functions:
+  # =========================================================================
+  # Data Source Registry
+  # =========================================================================
+  # Central registry that controls:
+  #   1. UI toggles — each source appears as an on/off switch in the frontend
+  #   2. Per-message filtering — users can select active sources per request
+  #   3. Tool auto-inheritance — agents with no explicit `tools` list receive
+  #      every tool listed here (use `exclude_tools` on agents to specialize)
+  #
+  # Adding a new tool or MCP function group? Just add it here — all agents
+  # pick it up automatically. No per-agent config changes needed.
+  #
+  # Source entry fields:
+  #   id            — Unique key used in API payloads and filtering
+  #   name          — Display name shown in the UI
+  #   description   — Human-readable description shown in the UI
+  #   tools         — List of NAT function names or function group names
+  #   requires_auth — (default: false) If true, the UI greys out this source
+  #                   until the user signs in. Use for sources that need
+  #                   user-level OAuth tokens (e.g., enterprise SSO).
+  #                   Sources using backend API keys (Tavily, Serper) should
+  #                   leave this false.
+  #   default_enabled — (default: true) Whether enabled by default
+  #
+  # See docs/source/customization/tools-and-sources.md for full details.
+  # =========================================================================
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: structured_data
+        name: "Enterprise Structured Data"
+        description: "Query structured enterprise data through GSF."
+        tools:
+          - gsf
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        description: "Search uploaded documents and files."
+        tools:
+          - knowledge_search
+      # Uncomment when paper_search_tool is enabled (requires SERPER_API_KEY)
+      # - id: paper_search
+      #   name: "Academic Papers"
+      #   description: "Search academic papers and scientific publications."
+      #   tools:
+      #     - paper_search_tool
+
+  web_search_tool:
+    _type: tavily_web_search
+    max_results: 5
+    max_content_length: 1000
+
+  advanced_web_search_tool:
+    _type: tavily_web_search
+    max_results: 2
+    advanced_search: true
+
+  # Knowledge Retrieval (see sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md)
+  knowledge_search:
+    _type: knowledge_retrieval
+    backend: llamaindex
+    collection_name: ${COLLECTION_NAME:-test_collection}
+    generate_summary: true
+    summary_model: summary_llm                     # Required when generate_summary: true
+    summary_db: ${AIQ_SUMMARY_DB:-sqlite+aiosqlite:///./summaries.db}
+    top_k: 5
+    chroma_dir: ${AIQ_CHROMA_DIR:-/tmp/chroma_data}
+
+  # Paper Search (optional - requires SERPER_API_KEY)
+  # Uncomment the block below and set SERPER_API_KEY to enable academic paper search.
+  # paper_search_tool:
+  #   _type: paper_search
+  #   max_results: 5
+  #   serper_api_key: ${SERPER_API_KEY}
+
+  # =========================================================================
+  # Agents
+  # =========================================================================
+  # Tool inheritance: agents with no `tools` list inherit ALL tools from the
+  # data_source_registry above. Use `exclude_tools` to remove specific tools
+  # from an agent (e.g., give shallow the basic search, deep the advanced).
+  # To bypass auto-inherit entirely, set an explicit `tools` list.
+  # =========================================================================
+  intent_classifier:
+    _type: context_aware_intent_router
+    llm: nemotron_lightning_intent_llm
+    catalog_tool: gsf__catalog_search
+    catalog_source_id: structured_data
+    max_catalog_results: 10
+    # Unscoped chat requests reach the DS agent only when catalog coverage clears this
+    # threshold. Tune per deployment: a test deployment measured 0.5 coverage on a
+    # representative question, which falls back to shallow at the 0.6 default.
+    catalog_confidence_threshold: ${AIQ_CATALOG_CONFIDENCE_THRESHOLD:-0.6}
+    verbose: true
+
+  clarifier_agent:
+    _type: clarifier_agent
+    llm: nemotron_ultra_llm
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
+    max_turns: 3
+    log_response_max_chars: 2000
+
+  shallow_research_agent:
+    _type: shallow_research_agent
+    llm: nemotron_lightning_agent_llm
+    # tools: omitted -> inherits all from data_source_registry
+    exclude_tools:                     # Remove advanced variant; shallow uses web_search_tool
+      - advanced_web_search_tool
+    max_llm_turns: 10
+    max_tool_iterations: 5
+
+  deep_research_agent:
+    _type: deep_research_agent
+    enable_citation_verification: true
+    orchestrator_llm: nemotron_ultra_llm
+    source_router_llm: nemotron_ultra_llm
+    researcher_llm: nemotron_ultra_llm
+    planner_llm: nemotron_ultra_llm
+    writer_llm: nemotron_ultra_writer_llm
+    # tools: omitted -> inherits all from data_source_registry
+    exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool
+      - web_search_tool
+
+  data_science_agent:
+    _type: data_science_agent
+    llm: nemotron_ultra_llm
+    tools:
+      - gsf
+      - knowledge_search
+      - web_search_tool
+    # The router submits this as an async job, which always runs headless.
+    interaction_mode: headless
+    recursion_limit: 48
+    verbose: true
+
+  data_science_hybrid_adapter:
+    _type: data_science_hybrid_adapter
+    agent: data_science_agent
+
+workflow:
+  _type: chat_deepresearcher_agent
+  hybrid_research_agent: data_science_hybrid_adapter
+  enable_escalation: true
+  enable_clarifier: true
+  use_async_deep_research: true
+  checkpoint_db: ${AIQ_CHECKPOINT_DB:-./checkpoints.db}
+  relay:
+    observability:
+      atof:
+        enabled: true
+        output_directory: ./relay
+        filename: aiq-relay.atof.jsonl
+        mode: append
+      # Uncomment to export Relay traces to a local Phoenix instance.
+      # opentelemetry:
+      #   enabled: true
+      #   endpoints:
+      #     - type: openinference
+      #       endpoint: http://localhost:6006/v1/traces
+      #       service_name: aiq-relay
+      #       resource_attributes:
+      #         openinference.project.name: aiq-relay
+      #         deployment.environment: development

--- a/docs/source/architecture/agents/data-science-agent.md
+++ b/docs/source/architecture/agents/data-science-agent.md
@@ -123,6 +123,62 @@ only searches an existing collection. TLS verification remains enabled by
 default; trusted test routes using a self-signed chain can set
 `RAG_VERIFY_SSL=false` locally.
 
+## Async execution
+
+A data-science run routinely takes several minutes, which is longer than a
+browser tab can be relied on to stay open. The agent is therefore submitted as
+an async job rather than held open on a request: the HTTP call returns a
+`job_id` immediately and the run continues in a Dask worker. Closing or
+refreshing the page does not cancel it, and reconnecting to the same `job_id`
+replays the stored events and returns the final report.
+
+This reuses the shared async job API described in
+[REST API](../../integration/rest-api.md); no data-science-specific endpoint
+exists. The agent is registered as `data_science` in the async agent registry,
+so it appears in `GET /v1/jobs/async/agents` whenever the active workflow
+configures a `data_science_agent` function.
+
+```bash
+# Submit; returns immediately with a job_id
+curl -X POST http://localhost:8000/v1/jobs/async/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_type": "data_science", "input": "Which regions missed forecast last quarter?"}'
+
+# Reconnect at any time, including after a page refresh
+curl -N http://localhost:8000/v1/jobs/async/job/<job_id>/stream
+```
+
+Serve the web profile, which adds the `aiq_api` front end:
+
+```bash
+dotenv -f deploy/.env run nat serve \
+  --config_file configs/config_web_data_science.yml --port 8000
+```
+
+Async jobs run in a worker that reloads the config file, so
+`NAT_CONFIG_FILE` must point at the same profile and
+`NAT_DASK_SCHEDULER_ADDRESS` must be set. Without them the submit route is
+replaced by a guarded stub that returns 503.
+
+### Behavior differences from a synchronous run
+
+- **Interaction mode is forced to `headless`.** A worker has no channel back to
+  the user, so a clarifying question would strand the job in a terminal
+  question instead of an answer. Clarification is a pre-submission concern,
+  exactly as it is for deep research. The configured `interaction_mode` is
+  honored only on the synchronous CLI path.
+- **Progress is streamed as SSE events**, not returned in one response. Tool
+  calls, model turns, and the citation-verified final report are emitted
+  through the standard job event stream.
+- **Sandbox concurrency caps apply.** When `AIQ_MAX_SANDBOXES_PER_PRINCIPAL` or
+  `AIQ_MAX_SANDBOXES_GLOBAL` is set, submissions are capped for agents that
+  reach a sandbox — including through the `stateful_python` tool, which owns
+  the sandbox reference rather than the agent config.
+- **Per-request analysis artifacts still belong to the run.** The temporary
+  analysis directory and any OpenShell sandbox are created and released inside
+  the agent run, so cancellation and expiry release them the same way a
+  synchronous run does.
+
 ## Product Hybrid integration
 
 The context-aware Chat Researcher router performs one bounded GSF catalog probe

--- a/docs/source/architecture/agents/data-science-agent.md
+++ b/docs/source/architecture/agents/data-science-agent.md
@@ -146,6 +146,9 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 
 # Reconnect at any time, including after a page refresh
 curl -N http://localhost:8000/v1/jobs/async/job/<job_id>/stream
+
+# Or resume from the last event a client already received
+curl -N http://localhost:8000/v1/jobs/async/job/<job_id>/stream/<last_event_id>
 ```
 
 Serve the web profile, which adds the `aiq_api` front end:

--- a/docs/source/architecture/agents/data-science-agent.md
+++ b/docs/source/architecture/agents/data-science-agent.md
@@ -163,6 +163,28 @@ Async jobs run in a worker that reloads the config file, so
 `NAT_DASK_SCHEDULER_ADDRESS` must be set. Without them the submit route is
 replaced by a guarded stub that returns 503.
 
+### Routing from the chat UI
+
+`configs/config_web_data_science_hybrid.yml` wires the agent into the chat
+router so a browser request can reach it. Three pieces are required together:
+
+- `intent_classifier` must use `_type: context_aware_intent_router`. The plain
+  `intent_classifier` has no `hybrid_research` route, so DS is unreachable
+  without this regardless of the rest.
+- `data_science_hybrid_adapter` must be defined with an `agent` reference.
+- `workflow.hybrid_research_agent` must point at that adapter.
+
+The router probes the GSF catalog on each research request. A request carrying
+an explicit `database_name` always takes the Hybrid path; an unscoped request
+takes it only when catalog coverage clears `catalog_confidence_threshold`,
+otherwise it falls back to shallow or deep. That threshold is deployment
+specific and needs tuning against real catalog content.
+
+When a submitter is configured the router submits DS as an async job and
+returns a `job_escalation` message carrying the job id, which the web UI
+consumes exactly as it does a deep-research job. Without a submitter — the
+synchronous CLI, which has no job store — the hybrid route still runs inline.
+
 ### Behavior differences from a synchronous run
 
 - **Interaction mode is forced to `headless`.** A worker has no channel back to

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -63,7 +63,8 @@ curl http://localhost:8000/v1/jobs/async/agents
 {
   "agents": [
     {"agent_type": "deep_researcher", "description": "Performs comprehensive multi-loop deep research"},
-    {"agent_type": "shallow_researcher", "description": "Performs quick single-turn research"}
+    {"agent_type": "shallow_researcher", "description": "Performs quick single-turn research"},
+    {"agent_type": "data_science", "description": "Analyzes enterprise structured data, documents, and web evidence in one autonomous loop"}
   ]
 }
 ```
@@ -85,7 +86,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `agent_type` | `string` | Yes | Agent identifier (for example, `deep_researcher`, `shallow_researcher`) |
+| `agent_type` | `string` | Yes | Agent identifier (for example, `deep_researcher`, `shallow_researcher`, `data_science`) |
 | `input` | `string` | Yes | Research query. Must be non-blank after trimming (whitespace-only is rejected with 422) |
 | `job_id` | `string` | No | Custom job ID. Auto-generated UUID if omitted. Pattern: `[a-zA-Z0-9_-]`, max 64 chars |
 | `expiry_seconds` | `integer` | No | Job expiry in seconds. Range: 600--604800 (10 min to 7 days). Default from config |

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -68,6 +68,19 @@ _DEEP_RESEARCH_AGENT_KWARGS = frozenset(
 _CONFIGURABLE_AGENT_KWARGS = frozenset({"config", "job_id"})
 _JOB_SCOPED_AGENT_KWARGS = frozenset({"job_id"})
 _SHALLOW_RESEARCH_AGENT_KWARGS = frozenset({"max_tool_iterations", "enforce_citations"})
+_DATA_SCIENCE_AGENT_KWARGS = frozenset(
+    {
+        "llm",
+        "recursion_limit",
+        "interaction_mode",
+        "response_mode",
+        "gsf_catalog_call_limit",
+        "gsf_text_to_sql_call_limit",
+        "gsf_cache_repeated_calls",
+        "python_call_limit",
+        "finalization_model_call_limit",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -1216,15 +1229,43 @@ def _create_agent_instance(
     Create an agent instance, supporting different constructor patterns.
 
     Tries in order:
-    1. DeepResearcherAgent explicit config pattern
-    2. llm_provider + tools + config/job_id pattern
-    3. llm_provider + tools + job_id pattern
-    4. ShallowResearcherAgent config pattern
-    5. llm_provider + tools pattern
-    6. llm + tools pattern (simpler agents)
+    1. DataScienceAgent explicit config pattern
+    2. DeepResearcherAgent explicit config pattern
+    3. llm_provider + tools + config/job_id pattern
+    4. llm_provider + tools + job_id pattern
+    5. ShallowResearcherAgent config pattern
+    6. llm_provider + tools pattern
+    7. llm + tools pattern (simpler agents)
     """
+    from aiq_agent.agents.data_science.register import DataScienceAgentConfig
     from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
     from aiq_agent.agents.shallow_researcher.register import ShallowResearchAgentConfig
+
+    if isinstance(fn_config, DataScienceAgentConfig) and _constructor_accepts_explicit_kwargs(
+        agent_cls, _DATA_SCIENCE_AGENT_KWARGS
+    ):
+        # An async job has no channel back to the user, so a clarifying question
+        # would strand the job. Clarification is a pre-submission concern (the
+        # chat workflow's clarifier), exactly as it is for deep research.
+        if fn_config.interaction_mode != "headless":
+            logger.info(
+                "Running data_science_agent headless for job %s (configured interaction_mode=%s)",
+                job_id,
+                fn_config.interaction_mode,
+            )
+        return agent_cls(
+            llm=llm,
+            tools=tools,
+            callbacks=callbacks,
+            recursion_limit=fn_config.recursion_limit,
+            interaction_mode="headless",
+            response_mode=fn_config.response_mode,
+            gsf_catalog_call_limit=fn_config.gsf_catalog_call_limit,
+            gsf_text_to_sql_call_limit=fn_config.gsf_text_to_sql_call_limit,
+            gsf_cache_repeated_calls=fn_config.gsf_cache_repeated_calls,
+            python_call_limit=fn_config.python_call_limit,
+            finalization_model_call_limit=fn_config.finalization_model_call_limit,
+        )
 
     if isinstance(fn_config, DeepResearchAgentConfig) and _constructor_accepts_explicit_kwargs(
         agent_cls, _DEEP_RESEARCH_AGENT_KWARGS

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -634,6 +634,7 @@ async def run_agent_job(
     output_metadata: dict[str, Any] | None = None,
     owner_user_id: str | None = None,
     admission_token: str | None = None,
+    database_name: str | None = None,
 ):
     """
     Dask task to run any registered agent with cancellation support and telemetry.
@@ -962,6 +963,7 @@ async def run_agent_job(
                                 data_sources=data_sources,
                                 event_store=event_store,
                                 initial_files=initial_files,
+                                database_name=database_name,
                             )
 
                         result = await run_relay_workflow(
@@ -1358,6 +1360,7 @@ async def _run_agent(
     data_sources: list[str] | None = None,
     event_store: EventStore | None = None,
     initial_files: dict[str, Any] | None = None,
+    database_name: str | None = None,
 ) -> Any:
     """
     Run the agent, supporting different run() signatures.
@@ -1396,6 +1399,10 @@ async def _run_agent(
                 state_kwargs["data_sources"] = data_sources
             if initial_files and has_fields and "files" in state_cls.model_fields:
                 state_kwargs["files"] = initial_files
+            # A router-resolved database scope is authoritative for the request, so the
+            # worker must not fall back to the agent's configured default.
+            if database_name and has_fields and "database_name" in state_cls.model_fields:
+                state_kwargs["database_name"] = database_name
             if available_documents:
                 # Convert dicts to AvailableDocument if the state class expects them
                 try:
@@ -1417,6 +1424,8 @@ async def _run_agent(
                 state["data_sources"] = data_sources
             if initial_files:
                 state["files"] = initial_files
+            if database_name:
+                state["database_name"] = database_name
             if available_documents:
                 state["available_documents"] = available_documents
 

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -141,6 +141,7 @@ async def submit_agent_job(
     initial_files: dict[str, Any] | None = None,
     output_metadata: dict[str, Any] | None = None,
     allow_internal: bool = False,
+    database_name: str | None = None,
 ) -> str:
     """
     Submit an agent job to the Dask cluster.
@@ -167,6 +168,9 @@ async def submit_agent_job(
         initial_files: Optional DeepAgents virtual filesystem files to seed into worker state.
         output_metadata: Optional metadata persisted with the final job output.
         allow_internal: Allow trusted callers to submit an internal-only agent.
+        database_name: Optional database scope the router resolved for this request.
+            Scoped requests are authoritative, so the worker must rebuild agent state
+            with the same scope rather than falling back to the configured default.
 
     Returns:
         The job ID.
@@ -430,6 +434,7 @@ async def submit_agent_job(
                 output_metadata,
                 principal_user_id(principal),
                 admission_token,
+                database_name,
             ],
         ),
         name=f"submit-job-{resolved_job_id}",

--- a/frontends/aiq_api/src/aiq_api/registry.py
+++ b/frontends/aiq_api/src/aiq_api/registry.py
@@ -124,3 +124,10 @@ register_agent(
     description="Internal child agent for report edit follow-up",
     public=False,
 )
+
+register_agent(
+    agent_type="data_science",
+    class_path="aiq_agent.agents.data_science.agent.DataScienceAgent",
+    config_name="data_science_agent",
+    description="Analyzes enterprise structured data, documents, and web evidence in one autonomous loop",
+)

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -252,16 +252,51 @@ def _sandbox_caps_configured() -> bool:
     return "AIQ_MAX_SANDBOXES_PER_PRINCIPAL" in os.environ or "AIQ_MAX_SANDBOXES_GLOBAL" in os.environ
 
 
+def _sandbox_enabled(sandbox: Any) -> bool:
+    """Return whether a resolved sandbox config is active."""
+    if sandbox is None:
+        return False
+    return bool(getattr(sandbox, "enabled", True))
+
+
+def _tool_config_uses_sandbox(builder: Any, fn_config: Any) -> bool:
+    """Return whether any tool the agent can resolve owns a sandbox.
+
+    Agents such as ``data_science`` never declare ``sandbox`` themselves: the
+    analysis tool (``stateful_python``) holds the sandbox ``FunctionRef``. Walk
+    the agent's effective tool refs so the submit-path cap covers those jobs
+    too, mirroring how the worker resolves tools.
+    """
+    tool_refs = getattr(fn_config, "tools", None) or get_all_tool_refs()
+    excluded = set(getattr(fn_config, "exclude_tools", None) or [])
+    for tool_ref in tool_refs:
+        if tool_ref in excluded:
+            continue
+        try:
+            tool_config = builder.get_function_config(tool_ref)
+        except Exception:  # noqa: BLE001 - an unresolvable ref cannot enable a sandbox
+            continue
+        sandbox = getattr(tool_config, "sandbox", None)
+        if isinstance(sandbox, str):
+            # A FunctionRef naming a separate sandbox function config.
+            try:
+                sandbox = builder.get_function_config(sandbox)
+            except Exception:  # noqa: BLE001 - same rationale as above
+                continue
+        if _sandbox_enabled(sandbox):
+            return True
+    return False
+
+
 def _agent_uses_sandbox(builder: Any, config_name: str) -> bool:
-    """Return whether the agent's function config enables a sandbox."""
+    """Return whether the agent reaches a sandbox directly or through a tool."""
     try:
         fn_config = builder.get_function_config(config_name)
     except Exception:  # noqa: BLE001 - missing/odd config means "no sandbox guard"
         return False
-    sandbox = getattr(fn_config, "sandbox", None)
-    if sandbox is None:
-        return False
-    return bool(getattr(sandbox, "enabled", True))
+    if _sandbox_enabled(getattr(fn_config, "sandbox", None)):
+        return True
+    return _tool_config_uses_sandbox(builder, fn_config)
 
 
 async def _enforce_sandbox_concurrency(db_url: str, principal: Any) -> None:

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -268,6 +268,14 @@ def _tool_config_uses_sandbox(builder: Any, fn_config: Any) -> bool:
     too, mirroring how the worker resolves tools.
     """
     tool_refs = getattr(fn_config, "tools", None) or get_all_tool_refs()
+    # exclude_tools holds exact runtime tool names while tool_refs holds function and
+    # group references. These coincide for plain-function tools, which is every tool
+    # that owns a sandbox today (stateful_python, registered under its function name).
+    # A group reference such as `gsf` would not match a child name such as
+    # `gsf__text_to_sql`, but no function group owns a sandbox. Matching exactly here
+    # keeps this off the async builder.get_tools() path on every submit; if a group
+    # ever owns a sandbox, resolve runtime names instead. Erring toward "uses a
+    # sandbox" only over-applies an opt-in cap rather than letting one escape it.
     excluded = set(getattr(fn_config, "exclude_tools", None) or [])
     for tool_ref in tool_refs:
         if tool_ref in excluded:

--- a/frontends/aiq_api/tests/test_data_science_async_job.py
+++ b/frontends/aiq_api/tests/test_data_science_async_job.py
@@ -253,3 +253,78 @@ async def test_list_agents_exposes_data_science_when_configured() -> None:
 
     assert response.status_code == 200
     assert [agent["agent_type"] for agent in response.json()["agents"]] == ["data_science"]
+
+
+class TestDatabaseScopePropagation:
+    """A router-resolved database scope must survive into the worker.
+
+    A request carrying ``database_name`` always takes the Hybrid path, so this is
+    exactly the path that must not lose its scope: rebuilding agent state without
+    it silently queries the agent's configured default instead.
+    """
+
+    class _ScopedAgent:
+        """Minimal state-based agent, matching the DS agent's run signature."""
+
+        def __init__(self):
+            self.seen = None
+
+        async def run(self, state):
+            self.seen = state
+            return state
+
+    @staticmethod
+    def _state_cls():
+        from aiq_agent.agents.data_science.models import DataScienceAgentState
+
+        return DataScienceAgentState
+
+    @pytest.mark.asyncio
+    async def test_database_name_reaches_agent_state(self, monkeypatch) -> None:
+        from aiq_api.jobs import runner as runner_module
+
+        agent = self._ScopedAgent()
+        monkeypatch.setattr(runner_module, "_get_agent_state_class", lambda _a: self._state_cls())
+        monkeypatch.setattr(
+            runner_module,
+            "run_with_cancellation",
+            lambda coro, _monitor, event_store=None: coro,
+        )
+
+        result = await runner_module._run_agent(
+            agent=agent,
+            input_text="Which state has the most orders?",
+            monitor=SimpleNamespace(),
+            database_name="northwind",
+        )
+
+        assert result.database_name == "northwind"
+        assert agent.seen.database_name == "northwind"
+
+    @pytest.mark.asyncio
+    async def test_unscoped_request_leaves_database_name_unset(self, monkeypatch) -> None:
+        from aiq_api.jobs import runner as runner_module
+
+        agent = self._ScopedAgent()
+        monkeypatch.setattr(runner_module, "_get_agent_state_class", lambda _a: self._state_cls())
+        monkeypatch.setattr(
+            runner_module,
+            "run_with_cancellation",
+            lambda coro, _monitor, event_store=None: coro,
+        )
+
+        result = await runner_module._run_agent(
+            agent=agent,
+            input_text="Which state has the most orders?",
+            monitor=SimpleNamespace(),
+        )
+
+        assert result.database_name is None
+
+    def test_submit_agent_job_accepts_a_database_scope(self) -> None:
+        """Guards the submission boundary: a missing parameter would be a silent drop."""
+        import inspect
+
+        from aiq_api.jobs.submit import submit_agent_job
+
+        assert "database_name" in inspect.signature(submit_agent_job).parameters

--- a/frontends/aiq_api/tests/test_data_science_async_job.py
+++ b/frontends/aiq_api/tests/test_data_science_async_job.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async-job support for the data-science agent."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _RecordingDataScienceAgent:
+    """Stand-in that captures the kwargs the job runner constructs it with."""
+
+    def __init__(
+        self,
+        *,
+        llm,
+        tools,
+        recursion_limit: int = 64,
+        callbacks=(),
+        interaction_mode: str = "interactive",
+        response_mode: str = "standard",
+        gsf_catalog_call_limit: int | None = None,
+        gsf_text_to_sql_call_limit: int | None = None,
+        gsf_cache_repeated_calls: bool = True,
+        python_call_limit: int | None = None,
+        finalization_model_call_limit: int | None = None,
+    ) -> None:
+        self.llm = llm
+        self.tools = tools
+        self.recursion_limit = recursion_limit
+        self.callbacks = callbacks
+        self.interaction_mode = interaction_mode
+        self.response_mode = response_mode
+        self.gsf_catalog_call_limit = gsf_catalog_call_limit
+        self.gsf_text_to_sql_call_limit = gsf_text_to_sql_call_limit
+        self.gsf_cache_repeated_calls = gsf_cache_repeated_calls
+        self.python_call_limit = python_call_limit
+        self.finalization_model_call_limit = finalization_model_call_limit
+
+
+def _ds_config(**overrides):
+    from aiq_agent.agents.data_science.register import DataScienceAgentConfig
+
+    return DataScienceAgentConfig(llm="data_science_llm", **overrides)
+
+
+def _create(fn_config, agent_cls=_RecordingDataScienceAgent):
+    from aiq_api.jobs.runner import _create_agent_instance
+
+    return _create_agent_instance(
+        agent_cls=agent_cls,
+        llm_provider=SimpleNamespace(),
+        llm="resolved-llm",
+        tools=["tool-a"],
+        fn_config=fn_config,
+        callbacks=["callback"],
+        job_id="job-1",
+    )
+
+
+class TestRegistry:
+    def test_data_science_is_registered_and_public(self) -> None:
+        from aiq_api.registry import AGENT_REGISTRY
+
+        entry = AGENT_REGISTRY["data_science"]
+
+        assert entry.class_path == "aiq_agent.agents.data_science.agent.DataScienceAgent"
+        assert entry.config_name == "data_science_agent"
+        assert entry.public is True
+
+    def test_registered_class_path_resolves(self) -> None:
+        from aiq_agent.agents.data_science.agent import DataScienceAgent
+        from aiq_api.jobs.runner import _load_agent_class
+        from aiq_api.registry import AGENT_REGISTRY
+
+        assert _load_agent_class(AGENT_REGISTRY["data_science"].class_path) is DataScienceAgent
+
+    def test_runner_can_discover_the_state_class(self) -> None:
+        """``_run_agent`` builds worker state from this lookup; a miss silently
+        degrades the job to an untyped dict state."""
+        from aiq_agent.agents.data_science.agent import DataScienceAgent
+        from aiq_agent.agents.data_science.models import DataScienceAgentState
+        from aiq_api.jobs.runner import _get_agent_state_class
+
+        agent = DataScienceAgent.__new__(DataScienceAgent)
+
+        state_cls = _get_agent_state_class(agent)
+
+        assert state_cls is DataScienceAgentState
+        assert "data_sources" in state_cls.model_fields
+
+
+class TestAgentConstruction:
+    def test_config_fields_reach_the_agent(self) -> None:
+        agent = _create(
+            _ds_config(
+                recursion_limit=32,
+                response_mode="fdabench_choice",
+                gsf_catalog_call_limit=2,
+                gsf_text_to_sql_call_limit=6,
+                gsf_cache_repeated_calls=False,
+                python_call_limit=8,
+                finalization_model_call_limit=18,
+            )
+        )
+
+        assert agent.llm == "resolved-llm"
+        assert agent.tools == ["tool-a"]
+        assert agent.callbacks == ["callback"]
+        assert agent.recursion_limit == 32
+        assert agent.response_mode == "fdabench_choice"
+        assert agent.gsf_catalog_call_limit == 2
+        assert agent.gsf_text_to_sql_call_limit == 6
+        assert agent.gsf_cache_repeated_calls is False
+        assert agent.python_call_limit == 8
+        assert agent.finalization_model_call_limit == 18
+
+    @pytest.mark.parametrize("configured_mode", ["interactive", "headless"])
+    def test_async_jobs_always_run_headless(self, configured_mode: str) -> None:
+        """A Dask worker has no channel back to the user, so a clarification
+        request would strand the job in a terminal question."""
+        agent = _create(_ds_config(interaction_mode=configured_mode))
+
+        assert agent.interaction_mode == "headless"
+
+    def test_real_agent_signature_matches_the_runner_branch(self) -> None:
+        """Guards against the branch silently falling through to the generic
+        ``llm + tools`` fallback, which would drop every configured limit."""
+        from aiq_agent.agents.data_science.agent import DataScienceAgent
+        from aiq_api.jobs.runner import _DATA_SCIENCE_AGENT_KWARGS
+        from aiq_api.jobs.runner import _constructor_accepts_explicit_kwargs
+
+        assert _constructor_accepts_explicit_kwargs(DataScienceAgent, _DATA_SCIENCE_AGENT_KWARGS)
+
+    def test_other_agent_configs_are_unaffected(self) -> None:
+        from aiq_agent.agents.shallow_researcher.register import ShallowResearchAgentConfig
+
+        captured = {}
+
+        class _Shallow:
+            def __init__(self, *, llm_provider, tools, max_tool_iterations, enforce_citations, callbacks):
+                captured["max_tool_iterations"] = max_tool_iterations
+
+        _create(ShallowResearchAgentConfig(llm="x", max_tool_iterations=3), agent_cls=_Shallow)
+
+        assert captured["max_tool_iterations"] == 3
+
+
+class TestSandboxDetection:
+    """The submit-path sandbox cap must see sandboxes owned by a tool.
+
+    ``data_science_agent`` has no ``sandbox`` field: the ``stateful_python``
+    tool holds the sandbox ``FunctionRef``.
+    """
+
+    @staticmethod
+    def _builder(configs: dict):
+        def _get_function_config(name: str):
+            if name not in configs:
+                raise ValueError(f"Function `{name}` not found")
+            return configs[name]
+
+        return SimpleNamespace(get_function_config=_get_function_config)
+
+    def test_detects_sandbox_behind_a_tool_function_ref(self) -> None:
+        from aiq_api.routes import jobs as jobs_module
+
+        builder = self._builder(
+            {
+                "data_science_agent": SimpleNamespace(tools=["gsf", "python"], exclude_tools=[]),
+                "python": SimpleNamespace(sandbox="ds_python_sandbox"),
+                "ds_python_sandbox": SimpleNamespace(provider="openshell"),
+                "gsf": SimpleNamespace(),
+            }
+        )
+
+        assert jobs_module._agent_uses_sandbox(builder, "data_science_agent") is True
+
+    def test_excluded_tool_does_not_enable_the_cap(self) -> None:
+        from aiq_api.routes import jobs as jobs_module
+
+        builder = self._builder(
+            {
+                "data_science_agent": SimpleNamespace(tools=["gsf", "python"], exclude_tools=["python"]),
+                "python": SimpleNamespace(sandbox="ds_python_sandbox"),
+                "ds_python_sandbox": SimpleNamespace(provider="openshell"),
+                "gsf": SimpleNamespace(),
+            }
+        )
+
+        assert jobs_module._agent_uses_sandbox(builder, "data_science_agent") is False
+
+    def test_no_sandbox_tool_is_still_false(self) -> None:
+        from aiq_api.routes import jobs as jobs_module
+
+        builder = self._builder(
+            {
+                "data_science_agent": SimpleNamespace(tools=["gsf"], exclude_tools=[]),
+                "gsf": SimpleNamespace(),
+            }
+        )
+
+        assert jobs_module._agent_uses_sandbox(builder, "data_science_agent") is False
+
+    def test_unresolvable_sandbox_ref_is_false(self) -> None:
+        from aiq_api.routes import jobs as jobs_module
+
+        builder = self._builder(
+            {
+                "data_science_agent": SimpleNamespace(tools=["python"], exclude_tools=[]),
+                "python": SimpleNamespace(sandbox="missing_sandbox"),
+            }
+        )
+
+        assert jobs_module._agent_uses_sandbox(builder, "data_science_agent") is False
+
+
+@pytest.mark.asyncio
+async def test_list_agents_exposes_data_science_when_configured() -> None:
+    import aiq_api.routes.jobs as jobs_routes
+
+    def _get_function_config(name: str):
+        if name != "data_science_agent":
+            raise ValueError(f"Function `{name}` not found")
+        return SimpleNamespace()
+
+    app = FastAPI()
+    await jobs_routes.register_job_routes(
+        app,
+        builder=SimpleNamespace(get_function_config=_get_function_config),
+        worker=SimpleNamespace(_dask_available=False, _job_store=None),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/v1/jobs/async/agents")
+
+    assert response.status_code == 200
+    assert [agent["agent_type"] for agent in response.json()["agents"]] == ["data_science"]

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -77,10 +77,10 @@ export const deriveArgSummary = (functionName: string, payload: string): string 
  * The backend (chat_researcher/agent.py `_job_escalation_message`) emits a compact JSON
  * payload rather than a prose sentence so escalation detection is immune to wording or
  * punctuation changes:
- *   {"type":"job_escalation","kind":"deep_research"|"report_edit","job_id":"<id>"}
+ *   {"type":"job_escalation","kind":"deep_research"|"report_edit"|"data_science","job_id":"<id>"}
  */
 interface JobEscalation {
-  kind: 'deep_research' | 'report_edit'
+  kind: 'deep_research' | 'report_edit' | 'data_science'
   jobId: string
 }
 
@@ -95,7 +95,7 @@ function parseJobEscalation(content?: string): JobEscalation | null {
   if (typeof parsed !== 'object' || parsed === null) return null
   const obj = parsed as Record<string, unknown>
   if (obj.type !== 'job_escalation') return null
-  if (obj.kind !== 'deep_research' && obj.kind !== 'report_edit') return null
+  if (obj.kind !== 'deep_research' && obj.kind !== 'report_edit' && obj.kind !== 'data_science') return null
   if (typeof obj.job_id !== 'string' || obj.job_id.length === 0) return null
   return { kind: obj.kind, jobId: obj.job_id }
 }

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -86,6 +86,7 @@ def _report_ref(job_id: str | None) -> str:
 # changes. Mirrored by the UI parser in frontends/ui/src/features/chat/hooks/use-websocket-chat.ts.
 _ESCALATION_KIND_DEEP_RESEARCH = "deep_research"
 _ESCALATION_KIND_REPORT_EDIT = "report_edit"
+_ESCALATION_KIND_DATA_SCIENCE = "data_science"
 
 
 def _research_workflow_failure() -> WorkflowFailure:
@@ -128,6 +129,7 @@ class ChatResearcherAgent:
         max_history: int = 5,
         deep_research_job_submitter: Callable[[Any], Awaitable[str]] | None = None,
         report_ask_fn: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
+        hybrid_research_job_submitter: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
         report_edit_job_submitter: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
         report_edit_fn: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
         report_seed_files_fn: Callable[[ChatResearcherState], Awaitable[dict[str, Any] | None]] | None = None,
@@ -149,6 +151,8 @@ class ChatResearcherAgent:
             max_history: Maximum number of messages to keep in history
             deep_research_job_submitter: Optional function to submit deep research as async job
             report_ask_fn: Optional function to answer questions against the active parent report
+            hybrid_research_job_submitter: Optional function to submit hybrid (data science)
+                research as an async job. When omitted, hybrid runs inline in-request.
             report_edit_job_submitter: Optional function to submit report edit child jobs
             checkpointer: Optional checkpointer for persistent state (defaults to MemorySaver)
         """
@@ -162,6 +166,7 @@ class ChatResearcherAgent:
         self.max_history = max_history
         self.deep_research_job_submitter = deep_research_job_submitter
         self.report_ask_fn = report_ask_fn
+        self.hybrid_research_job_submitter = hybrid_research_job_submitter
         self.report_edit_job_submitter = report_edit_job_submitter
         self.report_edit_fn = report_edit_fn
         self.report_seed_files_fn = report_seed_files_fn
@@ -201,6 +206,36 @@ class ChatResearcherAgent:
                 }
 
         async def hybrid_research_node(state: ChatResearcherState) -> dict[str, Any]:
+            # A data-science run takes minutes, so submit it as a durable async job when a
+            # submitter is wired. Running it inline would tie the answer to the open
+            # connection and lose it on a refresh. Mirrors deep_research_node.
+            if self.hybrid_research_job_submitter is not None:
+                try:
+                    job_id = await self.hybrid_research_job_submitter(state)
+                except Exception as e:
+                    if _JobAdmissionError and isinstance(e, _JobAdmissionError):
+                        logger.warning(
+                            "Hybrid research submission rejected (error_type=%s)",
+                            type(e).__name__,
+                        )
+                        return {
+                            "messages": [AIMessage(content=e.public_message)],
+                            "workflow_outcome": _research_workflow_failure(),
+                        }
+                    if _AuthError and isinstance(e, _AuthError):
+                        logger.warning(
+                            "Auth required before hybrid research submit (error_type=%s detail_%s)",
+                            type(e).__name__,
+                            log_content_metadata(e),
+                        )
+                        return {
+                            "messages": [AIMessage(content=str(e))],
+                            "workflow_outcome": _research_workflow_failure(),
+                        }
+                    raise
+                escalation = _job_escalation_message(_ESCALATION_KIND_DATA_SCIENCE, job_id)
+                return {"messages": [AIMessage(content=escalation)]}
+
             try:
                 if self.hybrid_research_fn is None:
                     raise RuntimeError("Hybrid research is not configured")

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -462,6 +462,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         wrapper_type=LLMFrameworkEnum.LANGCHAIN,
     )
 
+    hybrid_research_job_submitter = None
     deep_research_job_submitter = None
     # Wired to the async submitter only when a Dask scheduler is available; otherwise edit runs
     # inline via report_edit_fn (synchronous CLI).
@@ -604,8 +605,39 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                     output_metadata=output_metadata,
                 )
 
+            async def _submit_hybrid_job(state: ChatResearcherState) -> str:
+                """Submit the data-science agent as a durable async job.
+
+                Mirrors ``_submit_deep_job``: same principal resolution (so the job's
+                per-user MCP token key matches connect time) and the same auth-token
+                pass-through. Catalog context resolved by the router is not forwarded --
+                the async worker builds agent state from the query, and the agent
+                re-runs its own bounded catalog discovery.
+                """
+                principal = require_verified_principal()
+                owner = principal.email or principal.sub
+                query = state.original_query
+                if not query:
+                    if not state.messages:
+                        raise RuntimeError("Cannot submit data science job without messages.")
+                    query = state.messages[0].content
+                input_text = query if isinstance(query, str) else str(query)
+                if state.clarifier_result:
+                    input_text = f"{input_text}\n\n## Clarification Context\n{state.clarifier_result}"
+
+                return await submit_agent_job(
+                    agent_type="data_science",
+                    input_text=input_text,
+                    owner=owner,
+                    principal=principal,
+                    data_sources=state.data_sources,
+                    auth_token=get_auth_token(),
+                )
+
             deep_research_job_submitter = _submit_deep_job
             report_edit_job_submitter = _submit_report_edit_job
+            if config.hybrid_research_agent:
+                hybrid_research_job_submitter = _submit_hybrid_job
         else:
             logger.info(
                 "use_async_deep_research is enabled but NAT_DASK_SCHEDULER_ADDRESS is not set. "
@@ -629,6 +661,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         report_edit_fn=_inline_report_edit,
         report_seed_files_fn=_build_report_seed_files,
         hybrid_research_fn=hybrid_research_fn.ainvoke if hybrid_research_fn else None,
+        hybrid_research_job_submitter=hybrid_research_job_submitter,
         checkpointer=checkpointer,
         validate_deep_research_tools_fn=validate_deep_research_tools,
     )

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -656,6 +656,9 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                     principal=principal,
                     data_sources=state.data_sources,
                     auth_token=get_auth_token(),
+                    # A database-scoped request always routes Hybrid, so the scope must
+                    # survive into the worker or the job queries the configured default.
+                    database_name=state.database_name,
                 )
 
             deep_research_job_submitter = _submit_deep_job

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -69,6 +69,35 @@ _REPORT_ASK_TIMEOUT_S = 120
 _ensure_otel_redaction_registered()
 
 
+def _resolve_submission_query(state) -> str:
+    """Return the question a research job should answer for this turn.
+
+    Nothing on the hybrid route sets ``original_query``: the router goes straight
+    from ``intent_classifier`` to ``hybrid_research`` and never passes through
+    ``clarifier_node``, which is where deep research sets it. With a checkpointer
+    ``messages`` accumulates across turns, so ``messages[0]`` is the first message
+    of the whole conversation and a stale ``original_query`` can survive from an
+    earlier turn. Prefer the latest user message, matching how the inline
+    deep-research path resolves its own query.
+    """
+    from langchain_core.messages import HumanMessage
+
+    # Explicit precedence rather than get_latest_user_query, which falls back to the
+    # last message of any role when no user turn exists -- that would submit an
+    # assistant turn as the question instead of deferring to original_query.
+    query = next(
+        (message.content for message in reversed(state.messages) if isinstance(message, HumanMessage)),
+        None,
+    )
+    if not query:
+        query = state.original_query
+    if not query:
+        if not state.messages:
+            raise RuntimeError("Cannot submit a research job without messages.")
+        query = state.messages[-1].content
+    return query if isinstance(query, str) else str(query)
+
+
 def _log_conversation_reference(message: str, conversation_id: str) -> None:
     """Log a correlation reference without exposing the conversation identifier."""
     logger.info(message, log_identifier_ref(conversation_id))
@@ -616,12 +645,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 """
                 principal = require_verified_principal()
                 owner = principal.email or principal.sub
-                query = state.original_query
-                if not query:
-                    if not state.messages:
-                        raise RuntimeError("Cannot submit data science job without messages.")
-                    query = state.messages[0].content
-                input_text = query if isinstance(query, str) else str(query)
+                input_text = _resolve_submission_query(state)
                 if state.clarifier_result:
                     input_text = f"{input_text}\n\n## Clarification Context\n{state.clarifier_result}"
 

--- a/src/aiq_agent/agents/data_science/agent.py
+++ b/src/aiq_agent/agents/data_science/agent.py
@@ -30,6 +30,7 @@ from aiq_agent.common import load_prompt
 from aiq_agent.common import reset_session_registry
 from aiq_agent.common import sanitize_report
 from aiq_agent.common import set_session_registry
+from aiq_agent.common import validate_research_source_configuration
 from aiq_agent.common.citation_verification import verify_citations
 
 from .messages import is_clarification_request
@@ -256,6 +257,7 @@ class DataScienceAgent:
             context_schema=DataScienceAgentContext,
             name="data_science_agent",
         )
+        self.tools = agent_tools
         self.recursion_limit = recursion_limit
         self.source_tool_names = frozenset(tool_name_counts)
         self.callbacks = tuple(callbacks)
@@ -275,6 +277,9 @@ class DataScienceAgent:
 
     async def run(self, state: DataScienceAgentState) -> DataScienceAgentState:
         """Execute one request while preserving any caller-owned source registry."""
+        # Both the NAT registrar and the async job runner call this interface, so source
+        # selection and availability must be enforced here rather than by either adapter.
+        validate_research_source_configuration(state.data_sources, "data science", self.tools)
         self._validate_question(state)
         registry_token = None
         analysis_run_token = begin_analysis_run()

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -1399,7 +1399,10 @@ class TestHybridResearchAsyncSubmission:
     ):
         import json
 
-        async def submit_hybrid(_state):
+        submitted = {}
+
+        async def submit_hybrid(state):
+            submitted["state"] = state
             return "ds-job-1"
 
         async def fail_if_called(_state):
@@ -1423,6 +1426,9 @@ class TestHybridResearchAsyncSubmission:
             "kind": "data_science",
             "job_id": "ds-job-1",
         }
+        # The submitted state must carry the turn's own question, not the thread's first
+        # message, so the worker analyzes what the user actually asked.
+        assert submitted["state"].messages[-1].content == "Which state has the most orders?"
 
     @pytest.mark.asyncio
     async def test_runs_inline_when_no_submitter_is_configured(

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -1340,3 +1340,115 @@ class TestChatResearcherAgent:
         result = await agent.run(state, thread_id="test-thread-capture")
 
         assert result["last_report_markdown"] == "# Deep Report\n\nFindings."
+
+
+class TestHybridResearchAsyncSubmission:
+    """The hybrid (data-science) route must submit a durable job, not run in-request.
+
+    A DS run takes minutes. Running it inline ties the answer to the open websocket,
+    so a refresh loses the work -- the same failure mode the async job path exists to
+    prevent for deep research.
+    """
+
+    @pytest.fixture
+    def mock_shallow_research(self):
+        async def shallow(state_input):
+            messages = state_input.messages if hasattr(state_input, "messages") else state_input
+            result = MagicMock()
+            result.messages = list(messages) + [AIMessage(content="Here's a quick answer with sources.")]
+            return result
+
+        return shallow
+
+    @pytest.fixture
+    def mock_deep_research(self):
+        async def deep(state):
+            result = MagicMock()
+            result.messages = list(state.messages) + [AIMessage(content="Here's a comprehensive report.")]
+            return result
+
+        return deep
+
+    @pytest.fixture
+    def mock_clarifier(self):
+        async def clarifier(state_input):
+            messages = state_input.messages if hasattr(state_input, "messages") else state_input
+            result = MagicMock()
+            result.messages = list(messages)
+            result.clarifier_log = "User clarified: technical focus"
+            return result
+
+        return clarifier
+
+    @staticmethod
+    def _hybrid_intent():
+        async def _route(state):
+            return {
+                "user_intent": IntentResult(intent="research", raw=None, target="hybrid_research"),
+                "depth_decision": DepthDecision(decision="shallow", raw_reasoning="Structured data"),
+            }
+
+        return _route
+
+    @pytest.mark.asyncio
+    async def test_submitter_emits_data_science_escalation(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        import json
+
+        async def submit_hybrid(_state):
+            return "ds-job-1"
+
+        async def fail_if_called(_state):
+            raise AssertionError("inline hybrid research must not run when a submitter is set")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=self._hybrid_intent(),
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=mock_deep_research,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+            hybrid_research_fn=fail_if_called,
+            hybrid_research_job_submitter=submit_hybrid,
+        )
+
+        state = ChatResearcherState(messages=[HumanMessage(content="Which state has the most orders?")])
+        result = await agent.run(state, thread_id="test-thread-hybrid-escalation")
+
+        assert json.loads(result["messages"][-1].content) == {
+            "type": "job_escalation",
+            "kind": "data_science",
+            "job_id": "ds-job-1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_runs_inline_when_no_submitter_is_configured(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """Without a scheduler the CLI has no job store, so hybrid must still answer inline."""
+        called = {}
+
+        async def inline_hybrid(_state):
+            called["yes"] = True
+            return {"messages": [AIMessage(content="inline hybrid answer")]}
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=self._hybrid_intent(),
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=mock_deep_research,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+            hybrid_research_fn=inline_hybrid,
+        )
+
+        state = ChatResearcherState(messages=[HumanMessage(content="Which state has the most orders?")])
+        result = await agent.run(state, thread_id="test-thread-hybrid-inline")
+
+        assert called.get("yes") is True
+        assert result["messages"][-1].content == "inline hybrid answer"

--- a/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
@@ -536,3 +536,59 @@ class TestResolveEffectiveReportJobId:
         )
         result = await _resolve_effective_report_job_id(None, "conv-A", None, is_input_mode=False)
         assert result is None
+
+
+class TestResolveSubmissionQuery:
+    """Query derivation for async research submissions.
+
+    Regression cover for the hybrid route, which never passes through
+    ``clarifier_node`` and so never has ``original_query`` set.
+    """
+
+    @staticmethod
+    def _state(messages, original_query=None):
+        state = MagicMock()
+        state.messages = messages
+        state.original_query = original_query
+        return state
+
+    def test_uses_the_latest_user_message_across_turns(self) -> None:
+        from aiq_agent.agents.chat_researcher.register import _resolve_submission_query
+
+        state = self._state(
+            [
+                HumanMessage(content="What tables exist?"),
+                AIMessage(content="Several."),
+                HumanMessage(content="Which state has the most orders?"),
+            ]
+        )
+
+        assert _resolve_submission_query(state) == "Which state has the most orders?"
+
+    def test_latest_message_wins_over_a_stale_original_query(self) -> None:
+        """A previous turn's original_query must not leak into this turn's job."""
+        from aiq_agent.agents.chat_researcher.register import _resolve_submission_query
+
+        state = self._state(
+            [
+                HumanMessage(content="What tables exist?"),
+                AIMessage(content="Several."),
+                HumanMessage(content="Which state has the most orders?"),
+            ],
+            original_query="What tables exist?",
+        )
+
+        assert _resolve_submission_query(state) == "Which state has the most orders?"
+
+    def test_falls_back_to_original_query_when_no_user_message(self) -> None:
+        from aiq_agent.agents.chat_researcher.register import _resolve_submission_query
+
+        state = self._state([AIMessage(content="Only assistant turns.")], original_query="Earlier question")
+
+        assert _resolve_submission_query(state) == "Earlier question"
+
+    def test_raises_without_messages(self) -> None:
+        from aiq_agent.agents.chat_researcher.register import _resolve_submission_query
+
+        with pytest.raises(RuntimeError, match="without messages"):
+            _resolve_submission_query(self._state([]))

--- a/tests/aiq_agent/agents/data_science/test_agent.py
+++ b/tests/aiq_agent/agents/data_science/test_agent.py
@@ -676,7 +676,7 @@ async def test_run_allows_an_unselected_source_list(monkeypatch):
             name="gsf__text_to_sql",
             tool_call_id="call-1",
         ),
-        AIMessage(content="One row was returned."),
+        AIMessage(content="One row was returned [1].\n\n## Sources\n- [1] gsf__text_to_sql request gsf-1"),
     ]
     graph = MagicMock()
     graph.ainvoke = AsyncMock(return_value={"messages": grounded})

--- a/tests/aiq_agent/agents/data_science/test_agent.py
+++ b/tests/aiq_agent/agents/data_science/test_agent.py
@@ -650,3 +650,40 @@ def test_gsf_calls_keep_distinct_request_receipts():
         "gsf__text_to_sql request request-1",
         "gsf__text_to_sql request request-1 (2)",
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_empty_source_selection(monkeypatch):
+    """The async job runner constructs the agent directly and never calls the NAT
+    registrar, so `run` must enforce source selection itself."""
+    graph = MagicMock()
+    graph.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="unreachable")]})
+    agent = _agent(graph, monkeypatch)
+    state = DataScienceAgentState(messages=[HumanMessage(content="Rank users")], data_sources=[])
+
+    with pytest.raises(EmptySourceRegistryError):
+        await agent.run(state)
+
+    graph.ainvoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_allows_an_unselected_source_list(monkeypatch):
+    """`None` means "every tool available to the agent", not "no sources"."""
+    grounded = [
+        ToolMessage(
+            content='{"request_id":"gsf-1","sql":"SELECT 1","rows":[{"value":1}]}',
+            name="gsf__text_to_sql",
+            tool_call_id="call-1",
+        ),
+        AIMessage(content="One row was returned."),
+    ]
+    graph = MagicMock()
+    graph.ainvoke = AsyncMock(return_value={"messages": grounded})
+    agent = _agent(graph, monkeypatch)
+    state = DataScienceAgentState(messages=[HumanMessage(content="Rank users")], data_sources=None)
+
+    result = await agent.run(state)
+
+    graph.ainvoke.assert_awaited()
+    assert "One row was returned" in result.messages[-1].content

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -527,9 +527,9 @@ class TestSubmitDeepResearchJob:
         job_args = mock_job_store.submit_job.call_args.kwargs["job_args"]
         # Trailing worker args: available_documents, data_sources, auth_token,
         # encryption policy, initial_files, output_metadata, principal_user_id,
-        # admission fencing token.
-        assert job_args[-7] == ["web_search"]
-        assert job_args[-5].mode == "off"
+        # admission fencing token, database_name.
+        assert job_args[-8] == ["web_search"]
+        assert job_args[-6].mode == "off"
 
     @pytest.mark.asyncio
     async def test_submit_agent_job_passes_explicit_conversation_id_to_worker(self):
@@ -598,9 +598,9 @@ class TestSubmitDeepResearchJob:
         assert result == "test-job-id"
         job_args = mock_job_store.submit_job.call_args.kwargs["job_args"]
         # Encryption policy precedes the upstream report-context arguments.
-        assert job_args[-5].mode == "off"
-        assert job_args[-4] == initial_files
-        assert job_args[-3] == output_metadata
+        assert job_args[-6].mode == "off"
+        assert job_args[-5] == initial_files
+        assert job_args[-4] == output_metadata
 
     @pytest.mark.asyncio
     async def test_submit_with_custom_job_id(self):


### PR DESCRIPTION
#### Overview

Runs the Data Science Agent as an async job so a run survives a browser close or
refresh, and routes chat requests to it through the existing Hybrid slot.

A DS run routinely takes several minutes — longer than a tab can be relied on to
stay open. This reuses the existing async job infrastructure (Dask worker, job
store, event store, SSE replay) rather than adding anything new; the agent was
simply never plugged into it.

**Stacked on #457.** This branch is based on that PR's head, so the diff against
`develop` currently includes its commits. Only these 3 are mine:

| Commit | Change |
| :-- | :-- |
| `3132b9b` | Run the DS agent as an async job |
| `191db8b` | Docs: resumable job stream endpoint |
| `17821d3` | Route chat DS requests to an async job |

Please review against `arc144:feature/ds-agent-fdabench`, and merge only after
#457. Happy to rebase onto `develop` once it lands.

#### What changed

**Async execution** — registers `data_science` in the async agent registry; adds
a runner branch so the Dask worker builds the agent with its configured limits
instead of falling through to a generic constructor that silently dropped them;
forces `headless` (a worker has no channel to ask a clarifying question).

**A real bug this surfaced** — the job runner constructs the agent directly and
never calls the NAT registrar, so `validate_research_source_configuration` was
being skipped entirely. An empty source selection previously ran for minutes and
failed at finalization; it now fails immediately with the typed error. Deep
research already guards this inside `agent.py` for the same reason.

**Chat routing** — `hybrid_research_node` awaited DS inline and went straight to
`END`, which would have tied the answer to the open websocket and lost it on a
refresh. It now submits a job when a submitter is configured, mirroring
`deep_research_node`, and still runs inline for the synchronous CLI. Routing
requires three pieces together, including `context_aware_intent_router` — the
plain `intent_classifier` has no `hybrid_research` route, so DS is unreachable
without it.

**UI** — one line to accept a `data_science` escalation kind. The UI branches on
kind only for conversation renaming, so DS reuses the existing streaming,
reconnect, and report rendering unchanged.

#### DCO sign-off for the squash commit

Signed-off-by: Ashan Panduwawala <apanduwawala@nvidia.com>

#### Validation

Verified end to end against a live GSF deployment (not mocks):

- Submit returns a `job_id` in **~70ms**; killing the stream mid-run leaves the
  job `running`; reattaching at `/stream/<last_id>` resumes at the next event
  rather than restarting; the report is retrievable later on a fresh connection;
  a client that missed the entire run replays all events.
- Real GSF work throughout — `catalog_search` and `text_to_sql` both executed,
  one run returned 51 rows, answers consistent across runs.
- A database-scoped chat request returned
  `{"type":"job_escalation","kind":"data_science","job_id":...}` with a matching
  `Submitted data_science job` in the backend log.
- **End to end in the web UI.** A chat message routed to DS, submitted a job,
  and streamed to the browser. Refreshing mid-run reattached to the same job and
  resumed with nothing lost:

  ```
  Submitted data_science job 74dc30c9-...
  SSE: Replay complete for job 74dc30c9-... at event_id=431; switching to live mode
  SSE: Fetched 2 events (after_id=431)
  ```

  431 buffered events replayed on reconnect, then live consumption continued.
  The same close/reopen behaviour was separately confirmed on the deep-research
  path, which shares the job store, SSE endpoints, and UI reconnect code.

Commands:

```
uv run pytest tests/aiq_agent/agents/chat_researcher      # 234 passed
uv run pytest frontends/aiq_api/tests/test_data_science_async_job.py  # 13 passed
uv run pytest tests/aiq_agent/agents/data_science         # 40 passed
uv run ruff check . && uv run ruff format --check .
uv run python .agents/skills/aiq-configure-workflow/scripts/validate_config.py \
  configs/config_web_data_science_hybrid.yml              # exit 0
```

One pre-existing failure on the base branch, unrelated and not introduced here:
`test_submit_collision.py::test_submit_records_conversation_id_on_job_access`
patches `aiq_api.jobs.submit._current_conversation_id`, which does not exist.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO).
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity.

#### Where should reviewers start?

`frontends/aiq_api/src/aiq_api/jobs/runner.py` for the async construction branch,
and `src/aiq_agent/agents/chat_researcher/agent.py` for the inline→job change.

#### Known gaps

- **Routing threshold needs per-deployment tuning.** Unscoped chat requests
  reach DS only when catalog coverage clears `catalog_confidence_threshold`. A
  test deployment measured 0.5 against a representative question: at the 0.6
  default it fell back to shallow, and at 0.4 it routed to DS correctly. The
  config ships the 0.6 default and exposes the knob via
  `AIQ_CATALOG_CONFIDENCE_THRESHOLD`. Scoped requests (`database_name`) always
  take Hybrid regardless of coverage.
- **`stateful_python` sandbox path is unit-tested only** — verifying it needs an
  OpenShell image and policy file.
- **Separate bug, not fixed here:** `password: ${GSF_PASSWORD}` in the DS configs
  and `configuration-reference.md:390` is wrong. That field takes the *name* of
  an env var; `${...}` expands to the secret, so GSF silently registers as
  unavailable. The GSF package's own tests use the bare name.
- **Cosmetic:** the UI banner says "deep research" for any job kind, so a DS run
  is announced as deep research.

#### Related Issues

- Relates to #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous Data Science Agent jobs with persisted results, streaming, reconnection, and database-scoped execution.
  * Added hybrid research escalation to Data Science Agent jobs, with inline execution retained when async processing is unavailable.
  * Added `data_science` to the public agent registry, REST API documentation, and chat escalation workflow.
  * Added configurable web and hybrid Data Science profiles.

* **Bug Fixes**
  * Improved sandbox detection and validation of selected research sources.

* **Documentation**
  * Documented asynchronous Data Science Agent execution and API job submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
