### PR TITLE
fix(api): keep cleanup off shared Dask workers

### DIFF
--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -633,7 +633,6 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     Uses NAT's JobStore for job metadata and Dask for distributed execution.
     The /v1/data_sources endpoint is always registered regardless of Dask availability.
     """
-    import logging as std_logging
     import os
 
     from aiq_agent.common.data_source_registry import get_all_sources
@@ -688,8 +687,6 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     scheduler_address = getattr(worker, "_scheduler_address", None) or os.environ.get("NAT_DASK_SCHEDULER_ADDRESS")
     db_url = getattr(worker, "_db_url", None) or os.environ.get("NAT_JOB_STORE_DB_URL", "sqlite:///./data/jobs.db")
     config_path = getattr(worker, "_config_file_path", None) or os.environ.get("NAT_CONFIG_FILE", "")
-    log_level = getattr(worker, "_log_level", std_logging.INFO)
-    use_threads = getattr(worker, "_use_dask_threads", False)
     front_end_config = getattr(worker, "_front_end_config", None)
     default_expiry_seconds = getattr(front_end_config, "expiry_seconds", 86400) if front_end_config else 86400
     submit_route_registered = False
@@ -1358,10 +1355,9 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     # Start the ghost job reaper background task
     asyncio.create_task(_reap_ghost_jobs(job_store, db_url))
 
-    # Start periodic cleanup of expired jobs (NAT's job_info table) and old events (job_events table).
-    # NAT provides periodic_cleanup as a Dask task for job_info, but it must be explicitly submitted.
-    # We also run a local asyncio task for job_events cleanup since NAT doesn't manage that table.
-    _start_periodic_cleanup(job_store, scheduler_address, db_url, default_expiry_seconds, log_level, use_threads)
+    # Run job metadata and event retention in the API process. A never-ending
+    # cleanup coroutine submitted to shared Dask would permanently occupy a worker.
+    _start_periodic_cleanup(job_store, db_url, default_expiry_seconds)
 
 
 GHOST_JOB_TIMEOUT_SECONDS = 300  # 5 minutes without events = ghost job
@@ -1524,58 +1520,35 @@ _cleanup_task: asyncio.Task | None = None
 _PG_ADVISORY_LOCK_ID = 0x41495143_4C45414E  # "AIQCLEAN" in hex
 
 
-def _start_periodic_cleanup(
-    job_store,
-    scheduler_address: str,
-    db_url: str,
-    expiry_seconds: int,
-    log_level: int,
-    use_threads: bool,
-) -> None:
-    """
-    Start periodic cleanup of expired jobs and old events.
-
-    Submits NAT's periodic_cleanup as a Dask task (handles job_info expiry)
-    and starts a local asyncio task for coordinated event cleanup.
-    """
+def _start_periodic_cleanup(job_store, db_url: str, expiry_seconds: int) -> None:
+    """Start local cleanup of expired jobs, events, access rows, and artifacts."""
     global _cleanup_task
 
-    # Cleanup interval: half the expiry time, clamped to [60s, 3600s]
+    # Cleanup interval: half the expiry time, clamped to [60s, 3600s].
     cleanup_interval = max(60, min(expiry_seconds // 2, 3600))
 
-    # Submit NAT's periodic_cleanup as a long-running Dask task for job_info table
-    try:
-        from dask.distributed import fire_and_forget
-
-        from nat.front_ends.fastapi.async_jobs import periodic_cleanup
-
-        cleanup_future = job_store.dask_client.submit(
-            periodic_cleanup,
-            scheduler_address=scheduler_address,
-            db_url=db_url,
-            sleep_time_sec=cleanup_interval,
-            configure_logging=not use_threads,
-            log_level=log_level,
-        )
-        fire_and_forget(cleanup_future)
-        logger.info(
-            "Submitted periodic job cleanup task to Dask (interval=%ds, expiry=%ds)",
-            cleanup_interval,
-            expiry_seconds,
-        )
-    except Exception as e:
-        logger.warning("Failed to submit periodic cleanup to Dask: %s", e)
-
-    # Start local asyncio task for job_events table cleanup (NAT doesn't manage this table).
-    # Uses pg_try_advisory_xact_lock on PostgreSQL so only one pod runs cleanup per cycle.
-    # Cancel any previously-started task before overwriting the reference.
+    # Keep housekeeping off the shared Dask cluster. NAT's periodic_cleanup is an
+    # infinite Dask task; with one thread per worker it consumes an entire worker
+    # slot for the lifetime of the deployment.
     if _cleanup_task and not _cleanup_task.done():
         _cleanup_task.cancel()
-    _cleanup_task = asyncio.create_task(_cleanup_old_events_loop(db_url, expiry_seconds, cleanup_interval))
+    _cleanup_task = asyncio.create_task(
+        _cleanup_old_events_loop(
+            db_url,
+            expiry_seconds,
+            cleanup_interval,
+            job_store=job_store,
+        )
+    )
+    logger.info(
+        "Started local periodic job and event cleanup (interval=%ds, expiry=%ds)",
+        cleanup_interval,
+        expiry_seconds,
+    )
 
 
 async def stop_periodic_cleanup() -> None:
-    """Cancel the event cleanup background task. Call from shutdown handler."""
+    """Cancel the local periodic cleanup task. Call from shutdown handler."""
     global _cleanup_task
     if _cleanup_task and not _cleanup_task.done():
         _cleanup_task.cancel()
@@ -1584,44 +1557,84 @@ async def stop_periodic_cleanup() -> None:
         except asyncio.CancelledError:
             pass
         _cleanup_task = None
-        logger.info("Event cleanup task cancelled")
+        logger.info("Periodic cleanup task cancelled")
 
 
-async def _cleanup_old_events_loop(db_url: str, retention_seconds: int, interval_seconds: int) -> None:
+async def _cleanup_old_events_loop(
+    db_url: str,
+    retention_seconds: int,
+    interval_seconds: int,
+    *,
+    job_store=None,
+) -> None:
     """
-    Background task that periodically deletes old events from the job_events table
-    and removes events for jobs already marked as expired in job_info.
+    Periodically expire finished jobs and clean their retained data.
 
-    On PostgreSQL, uses pg_try_advisory_xact_lock so only one pod runs cleanup per cycle
-    when multiple pods share the same database.
+    PostgreSQL cleanup cycles use an advisory lock so multiple API replicas do
+    not perform the same work. Job cleanup remains local to the API process and
+    therefore does not consume a shared Dask worker slot.
     """
 
     is_postgres = db_url.startswith("postgres")
 
     logger.info(
-        "Event cleanup task started (retention=%ds, interval=%ds, advisory_lock=%s)",
+        "Periodic cleanup task started (retention=%ds, interval=%ds, advisory_lock=%s)",
         retention_seconds,
         interval_seconds,
         is_postgres,
     )
 
     # Run once immediately on startup to catch anything that aged out during downtime.
+    await _run_local_cleanup_cycle(job_store, db_url, retention_seconds, is_postgres)
+
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            await _run_local_cleanup_cycle(job_store, db_url, retention_seconds, is_postgres)
+        except asyncio.CancelledError:
+            logger.info("Periodic cleanup task stopped")
+            break
+
+
+async def _run_local_cleanup_cycle(job_store, db_url: str, retention_seconds: int, is_postgres: bool) -> None:
+    """Run one isolated job-retention and event-retention cycle."""
+    if job_store is not None:
+        try:
+            expired = await _run_job_cleanup(job_store, is_postgres)
+            if expired:
+                logger.info("Expired jobs cleaned up: %d", expired)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("Job cleanup error: %s", e)
+
     try:
         await _run_event_cleanup(db_url, retention_seconds, is_postgres)
     except asyncio.CancelledError:
         raise
     except Exception as e:
-        logger.warning("Event cleanup startup run failed: %s", e)
+        logger.warning("Event cleanup error: %s", e)
 
-    while True:
-        try:
-            await asyncio.sleep(interval_seconds)
-            await _run_event_cleanup(db_url, retention_seconds, is_postgres)
-        except asyncio.CancelledError:
-            logger.info("Event cleanup task stopped")
-            break
-        except Exception as e:
-            logger.warning("Event cleanup error: %s", e)
+
+async def _run_job_cleanup(job_store, is_postgres: bool) -> int | None:
+    """Expire finished jobs once, with one PostgreSQL replica elected per cycle."""
+    if not is_postgres:
+        return await job_store.cleanup_expired_jobs()
+
+    from sqlalchemy import text
+
+    # NAT's scoped session is keyed by asyncio task. Hold the election lock in
+    # this task and run cleanup in a child task so it receives its own DB session.
+    async with job_store.session() as lock_session:
+        locked = (
+            await lock_session.execute(
+                text("SELECT pg_try_advisory_xact_lock(:lock_id)"),
+                {"lock_id": _PG_ADVISORY_LOCK_ID},
+            )
+        ).scalar()
+        if not locked:
+            return None
+        return await asyncio.create_task(job_store.cleanup_expired_jobs())
 
 
 async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: bool) -> None:

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -1690,6 +1690,11 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
             expired_deleted = expired_result.rowcount
             access_deleted = cleanup_job_access(db_url, conn=conn)
 
+            # SQLite permits one writer at a time. Artifact cleanup uses its own
+            # connection, so release this connection's write lock first.
+            if not is_postgres:
+                conn.commit()
+
             # Artifact retention shares the job expiry boundary. Keep it inside
             # the leader's advisory-lock transaction so non-leader replicas
             # cannot run the same destructive cleanup concurrently.
@@ -1699,9 +1704,10 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
 
                 artifacts_deleted = build_artifact_store(db_url).cleanup_old_artifacts(retention_seconds)
             except Exception as e:  # noqa: BLE001 - retention is best-effort
-                logger.debug("Artifact cleanup skipped: %s", e)
+                logger.debug("Artifact cleanup skipped (%s)", type(e).__name__)
 
-            conn.commit()
+            if is_postgres:
+                conn.commit()
             return (time_deleted, expired_deleted, access_deleted, artifacts_deleted)
 
     time_deleted, expired_deleted, access_deleted, artifacts_deleted = await loop.run_in_executor(None, _do_cleanup)

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -1650,8 +1650,8 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
 
     loop = asyncio.get_running_loop()
 
-    def _do_cleanup() -> tuple[int, int, int]:
-        """Delete expired events/jobs/access rows synchronously; return removal counts."""
+    def _do_cleanup() -> tuple[int, int, int, int]:
+        """Delete expired retained data synchronously; return removal counts."""
         from sqlalchemy import text
 
         engine = EventStore._get_or_create_sync_engine(db_url)
@@ -1666,7 +1666,7 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
                     {"lock_id": _PG_ADVISORY_LOCK_ID},
                 ).scalar()
                 if not locked:
-                    return (0, 0, 0)
+                    return (0, 0, 0, 0)
 
             # 1. Time-based: delete events older than retention period
             if is_postgres:
@@ -1690,23 +1690,24 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
             expired_deleted = expired_result.rowcount
             access_deleted = cleanup_job_access(db_url, conn=conn)
 
+            # Artifact retention shares the job expiry boundary. Keep it inside
+            # the leader's advisory-lock transaction so non-leader replicas
+            # cannot run the same destructive cleanup concurrently.
+            artifacts_deleted = 0
+            try:
+                from aiq_agent.agents.deep_researcher.sandbox.artifacts import build_artifact_store
+
+                artifacts_deleted = build_artifact_store(db_url).cleanup_old_artifacts(retention_seconds)
+            except Exception as e:  # noqa: BLE001 - retention is best-effort
+                logger.debug("Artifact cleanup skipped: %s", e)
+
             conn.commit()
-            return (time_deleted, expired_deleted, access_deleted)
+            return (time_deleted, expired_deleted, access_deleted, artifacts_deleted)
 
-    time_deleted, expired_deleted, access_deleted = await loop.run_in_executor(None, _do_cleanup)
+    time_deleted, expired_deleted, access_deleted, artifacts_deleted = await loop.run_in_executor(None, _do_cleanup)
 
-    # Artifact retention shares the job expiry boundary (best-effort; the artifacts
-    # table only exists when artifact capture has been used).
-    try:
-        from aiq_agent.agents.deep_researcher.sandbox.artifacts import build_artifact_store
-
-        artifacts_deleted = await loop.run_in_executor(
-            None, lambda: build_artifact_store(db_url).cleanup_old_artifacts(retention_seconds)
-        )
-        if artifacts_deleted:
-            logger.info("Artifact cleanup: %d old artifacts removed", artifacts_deleted)
-    except Exception as e:  # noqa: BLE001 - retention is best-effort
-        logger.debug("Artifact cleanup skipped: %s", e)
+    if artifacts_deleted:
+        logger.info("Artifact cleanup: %d old artifacts removed", artifacts_deleted)
 
     if time_deleted > 0 or expired_deleted > 0 or access_deleted > 0:
         logger.info(

--- a/frontends/aiq_api/tests/test_periodic_cleanup.py
+++ b/frontends/aiq_api/tests/test_periodic_cleanup.py
@@ -23,6 +23,7 @@ import types
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -327,6 +328,65 @@ class TestCleanupOldEventsLoop:
 
         assert call_count >= 3, "Should have continued past the error"
 
+    @pytest.mark.asyncio
+    async def test_runs_job_cleanup_locally_without_dask_task(self):
+        """Job expiry should run in the API process without occupying a Dask worker."""
+        from aiq_api.routes.jobs import _cleanup_old_events_loop
+
+        mock_job_store = MagicMock()
+
+        async def mock_job_cleanup():
+            return 0
+
+        mock_job_store.cleanup_expired_jobs.side_effect = mock_job_cleanup
+
+        async def mock_event_cleanup(*_args):
+            return None
+
+        with patch("aiq_api.routes.jobs._run_event_cleanup", side_effect=mock_event_cleanup):
+            task = asyncio.create_task(
+                _cleanup_old_events_loop(
+                    db_url="sqlite+aiosqlite:///test.db",
+                    retention_seconds=3600,
+                    interval_seconds=9999,
+                    job_store=mock_job_store,
+                )
+            )
+            await asyncio.sleep(0.05)
+            task.cancel()
+            await task
+
+        mock_job_store.cleanup_expired_jobs.assert_called_once_with()
+        mock_job_store.dask_client.submit.assert_not_called()
+
+
+class TestRunJobCleanup:
+    """Tests for PostgreSQL cleanup leader election."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("lock_acquired", "expected_result"), [(True, 3), (False, None)])
+    async def test_only_lock_holder_expires_jobs(self, lock_acquired, expected_result):
+        from aiq_api.routes.jobs import _run_job_cleanup
+
+        job_store = MagicMock()
+        job_store.cleanup_expired_jobs = AsyncMock(return_value=3)
+
+        lock_result = MagicMock()
+        lock_result.scalar.return_value = lock_acquired
+        lock_session = MagicMock()
+        lock_session.execute = AsyncMock(return_value=lock_result)
+        session_context = MagicMock()
+        session_context.__aenter__ = AsyncMock(return_value=lock_session)
+        session_context.__aexit__ = AsyncMock(return_value=None)
+        job_store.session.return_value = session_context
+
+        assert await _run_job_cleanup(job_store, is_postgres=True) == expected_result
+
+        if lock_acquired:
+            job_store.cleanup_expired_jobs.assert_awaited_once_with()
+        else:
+            job_store.cleanup_expired_jobs.assert_not_awaited()
+
 
 # =========================================================================
 # _start_periodic_cleanup (orchestration)
@@ -336,112 +396,60 @@ class TestCleanupOldEventsLoop:
 class TestStartPeriodicCleanup:
     """Tests for _start_periodic_cleanup orchestration function."""
 
-    def test_submits_dask_cleanup_task(self):
-        """Should submit NAT's periodic_cleanup to Dask."""
-        from aiq_api.routes.jobs import _start_periodic_cleanup
+    def test_starts_one_local_cleanup_task_without_dask_submission(self):
+        """Housekeeping should not reserve a worker in the shared Dask pool."""
+        import aiq_api.routes.jobs as jobs_module
 
+        jobs_module._cleanup_task = None
         mock_job_store = MagicMock()
-        mock_future = MagicMock()
-        mock_job_store.dask_client.submit.return_value = mock_future
+        cleanup_coroutine = object()
+        mock_loop = MagicMock(return_value=cleanup_coroutine)
 
-        with patch("aiq_api.routes.jobs.asyncio.create_task"):
-            with patch("dask.distributed.fire_and_forget") as mock_faf:
-                _start_periodic_cleanup(
-                    job_store=mock_job_store,
-                    scheduler_address="tcp://localhost:8786",
-                    db_url="sqlite:///test.db",
-                    expiry_seconds=3600,
-                    log_level=20,
-                    use_threads=False,
-                )
-
-        mock_job_store.dask_client.submit.assert_called_once()
-        call_kwargs = mock_job_store.dask_client.submit.call_args[1]
-        assert call_kwargs["scheduler_address"] == "tcp://localhost:8786"
-        assert call_kwargs["db_url"] == "sqlite:///test.db"
-        assert call_kwargs["sleep_time_sec"] == 1800  # 3600 // 2
-        mock_faf.assert_called_once_with(mock_future)
-
-    def test_starts_event_cleanup_task(self):
-        """Should start a local asyncio task for event cleanup."""
-        from aiq_api.routes.jobs import _start_periodic_cleanup
-
-        mock_job_store = MagicMock()
-        mock_job_store.dask_client.submit.return_value = MagicMock()
-
-        with patch("aiq_api.routes.jobs.asyncio.create_task") as mock_create_task:
-            with patch("dask.distributed.fire_and_forget"):
-                _start_periodic_cleanup(
-                    job_store=mock_job_store,
-                    scheduler_address="tcp://localhost:8786",
-                    db_url="sqlite:///test.db",
-                    expiry_seconds=7200,
-                    log_level=20,
-                    use_threads=False,
-                )
-
-        mock_create_task.assert_called_once()
-
-    def test_cleanup_interval_clamped_max(self):
-        """Cleanup interval should be clamped to 3600s max."""
-        from aiq_api.routes.jobs import _start_periodic_cleanup
-
-        mock_job_store = MagicMock()
-        mock_job_store.dask_client.submit.return_value = MagicMock()
-
-        with patch("aiq_api.routes.jobs.asyncio.create_task"):
-            with patch("dask.distributed.fire_and_forget"):
-                _start_periodic_cleanup(
-                    job_store=mock_job_store,
-                    scheduler_address="tcp://localhost:8786",
-                    db_url="sqlite:///test.db",
-                    expiry_seconds=604800,  # 7 days
-                    log_level=20,
-                    use_threads=False,
-                )
-
-        call_kwargs = mock_job_store.dask_client.submit.call_args[1]
-        assert call_kwargs["sleep_time_sec"] == 3600
-
-    def test_cleanup_interval_clamped_min(self):
-        """Cleanup interval should be at least 60s."""
-        from aiq_api.routes.jobs import _start_periodic_cleanup
-
-        mock_job_store = MagicMock()
-        mock_job_store.dask_client.submit.return_value = MagicMock()
-
-        with patch("aiq_api.routes.jobs.asyncio.create_task"):
-            with patch("dask.distributed.fire_and_forget"):
-                _start_periodic_cleanup(
-                    job_store=mock_job_store,
-                    scheduler_address="tcp://localhost:8786",
-                    db_url="sqlite:///test.db",
-                    expiry_seconds=60,
-                    log_level=20,
-                    use_threads=False,
-                )
-
-        call_kwargs = mock_job_store.dask_client.submit.call_args[1]
-        assert call_kwargs["sleep_time_sec"] == 60
-
-    def test_dask_submit_failure_doesnt_block_event_cleanup(self):
-        """If Dask submit fails, event cleanup should still start."""
-        from aiq_api.routes.jobs import _start_periodic_cleanup
-
-        mock_job_store = MagicMock()
-        mock_job_store.dask_client.submit.side_effect = RuntimeError("Dask unavailable")
-
-        with patch("aiq_api.routes.jobs.asyncio.create_task") as mock_create_task:
-            _start_periodic_cleanup(
+        with (
+            patch("aiq_api.routes.jobs._cleanup_old_events_loop", new=mock_loop),
+            patch("aiq_api.routes.jobs.asyncio.create_task") as mock_create_task,
+        ):
+            jobs_module._start_periodic_cleanup(
                 job_store=mock_job_store,
-                scheduler_address="tcp://localhost:8786",
                 db_url="sqlite:///test.db",
                 expiry_seconds=3600,
-                log_level=20,
-                use_threads=False,
             )
 
-        mock_create_task.assert_called_once()
+        mock_loop.assert_called_once_with(
+            "sqlite:///test.db",
+            3600,
+            1800,
+            job_store=mock_job_store,
+        )
+        mock_create_task.assert_called_once_with(cleanup_coroutine)
+        mock_job_store.dask_client.submit.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("expiry_seconds", "expected_interval"),
+        [
+            (604800, 3600),
+            (60, 60),
+        ],
+    )
+    def test_cleanup_interval_is_clamped(self, expiry_seconds, expected_interval):
+        """Local cleanup interval should remain between one minute and one hour."""
+        import aiq_api.routes.jobs as jobs_module
+
+        jobs_module._cleanup_task = None
+        mock_job_store = MagicMock()
+        mock_loop = MagicMock(return_value=object())
+
+        with (
+            patch("aiq_api.routes.jobs._cleanup_old_events_loop", new=mock_loop),
+            patch("aiq_api.routes.jobs.asyncio.create_task"),
+        ):
+            jobs_module._start_periodic_cleanup(
+                job_store=mock_job_store,
+                db_url="sqlite:///test.db",
+                expiry_seconds=expiry_seconds,
+            )
+
+        assert mock_loop.call_args.args[2] == expected_interval
 
 
 # =========================================================================

--- a/frontends/aiq_api/tests/test_periodic_cleanup.py
+++ b/frontends/aiq_api/tests/test_periodic_cleanup.py
@@ -254,6 +254,67 @@ class TestRunEventCleanup:
         assert len(EventStore.get_events(db_url, "live-job")) == 1
 
     @pytest.mark.asyncio
+    async def test_sqlite_removes_expired_artifacts_after_event_cleanup(self, db_url):
+        """SQLite releases event writes before artifact retention uses a second connection."""
+        from sqlalchemy import text
+
+        from aiq_agent.agents.deep_researcher.sandbox.artifacts import Artifact
+        from aiq_agent.agents.deep_researcher.sandbox.artifacts import ArtifactKind
+        from aiq_agent.agents.deep_researcher.sandbox.artifacts import build_artifact_store
+        from aiq_api.routes.jobs import _run_event_cleanup
+
+        event_store = EventStore(db_url, job_id="old-job")
+        event_store.store({"type": "test", "data": {}})
+        _backdate_events(db_url, hours=2, job_id="old-job")
+        _create_expired_job(db_url, "expired-other-job")
+
+        artifact_store = build_artifact_store(db_url)
+        stored = artifact_store.put(
+            Artifact(
+                artifact_id="art_" + "a" * 32,
+                job_id="old-job",
+                kind=ArtifactKind.TEXT,
+                mime_type="text/plain",
+                filename="result.txt",
+                sandbox_path="/tmp/artifacts/result.txt",
+                storage_uri="",
+                sha256="b" * 64,
+                size_bytes=6,
+            ),
+            b"result",
+        )
+        with artifact_store._engine.connect() as conn:
+            conn.execute(
+                text("UPDATE artifacts SET created_at = datetime('now', '-2 seconds') WHERE artifact_id = :id"),
+                {"id": stored.artifact_id},
+            )
+            conn.commit()
+
+        await _run_event_cleanup(db_url, retention_seconds=1, is_postgres=False)
+
+        assert artifact_store.get(stored.job_id, stored.artifact_id) is None
+
+    @pytest.mark.asyncio
+    async def test_artifact_cleanup_error_does_not_log_endpoint(self, db_url, caplog):
+        """Artifact retention failures expose the exception type, not configured endpoints."""
+        from aiq_api.routes.jobs import _run_event_cleanup
+
+        _create_expired_job(db_url, "expired-job")
+        EventStore(db_url, job_id="active-job").store({"type": "test", "data": {}})
+        artifact_store = MagicMock()
+        artifact_store.cleanup_old_artifacts.side_effect = RuntimeError("https://secret-artifacts.internal")
+        caplog.set_level("DEBUG", logger="aiq_api.routes.jobs")
+
+        with patch(
+            "aiq_agent.agents.deep_researcher.sandbox.artifacts.build_artifact_store",
+            return_value=artifact_store,
+        ):
+            await _run_event_cleanup(db_url, retention_seconds=3600, is_postgres=False)
+
+        assert "RuntimeError" in caplog.text
+        assert "secret-artifacts.internal" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_postgres_non_leader_skips_artifact_cleanup(self):
         """Only the advisory-lock holder may delete retained artifacts."""
         from aiq_api.routes.jobs import _run_event_cleanup

--- a/frontends/aiq_api/tests/test_periodic_cleanup.py
+++ b/frontends/aiq_api/tests/test_periodic_cleanup.py
@@ -253,6 +253,34 @@ class TestRunEventCleanup:
         assert len(EventStore.get_events(db_url, "expired-job")) == 0
         assert len(EventStore.get_events(db_url, "live-job")) == 1
 
+    @pytest.mark.asyncio
+    async def test_postgres_non_leader_skips_artifact_cleanup(self):
+        """Only the advisory-lock holder may delete retained artifacts."""
+        from aiq_api.routes.jobs import _run_event_cleanup
+
+        lock_result = MagicMock()
+        lock_result.scalar.return_value = False
+        connection = MagicMock()
+        connection.execute.return_value = lock_result
+        engine = MagicMock()
+        engine.connect.return_value.__enter__.return_value = connection
+
+        with (
+            patch(
+                "aiq_api.jobs.event_store.EventStore._get_or_create_sync_engine",
+                return_value=engine,
+            ),
+            patch("aiq_agent.agents.deep_researcher.sandbox.artifacts.build_artifact_store") as mock_artifact_store,
+        ):
+            await _run_event_cleanup(
+                "postgresql+asyncpg://example.invalid/jobs",
+                retention_seconds=3600,
+                is_postgres=True,
+            )
+
+        mock_artifact_store.assert_not_called()
+        connection.commit.assert_not_called()
+
 
 # =========================================================================
 # _cleanup_old_events_loop (background task)


### PR DESCRIPTION
## Summary
- run NAT job expiry cleanup as a local API background task instead of an infinite shared-Dask task
- elect one PostgreSQL API replica per cleanup cycle with an advisory transaction lock
- preserve coordinated event, access-row, and artifact retention

## Production finding
The deployed shared scheduler showed `periodic_cleanup-*` permanently processing on one of four one-thread workers. An 8-task benchmark could use only three workers and took 6.103s instead of two 2s waves.

## Validation
- `pytest frontends/aiq_api/tests/test_periodic_cleanup.py`: 21 passed
- focused async-job suite: 71 passed before standalone cherry-pick
- ruff check and format-check passed
- runtime image smoke verified the patched module hash and no Dask submission in `_start_periodic_cleanup`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background maintenance.
  * Prevented overlapping cleanup across running instances.
  * Ensured expired jobs, related data, and stored artifacts are consistently removed.
  * Isolated cleanup errors so one failure does not interrupt other maintenance tasks.

* **Performance**
  * Reduced unnecessary distributed scheduling for routine maintenance.
  * Improved consistency and efficiency of scheduled cleanup across instances.
  * Added safeguards to keep cleanup intervals within a reliable operating range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->