### PR TITLE
fix(deep-research): normalize planner verification hints

### DIFF
--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -46,7 +46,6 @@ from aiq_agent.common.citation_verification import is_non_citable_status_output
 from aiq_agent.common.logging_utils import log_content_metadata
 
 from .models import ResearchNotes
-from .models import ResearchPlan
 from .resource_limits import DeepResearchResourceLimits
 from .resource_limits import StateBudgetLedger
 
@@ -139,26 +138,7 @@ class StructuredResponseTextFallbackMiddleware(AgentMiddleware):
         try:
             structured = self.schema.model_validate(payload)
         except ValidationError:
-            if self.schema is not ResearchPlan or not isinstance(payload, dict):
-                return response
-            constraints = payload.get("constraints")
-            if not isinstance(constraints, list):
-                return response
-            normalized_constraints = []
-            normalized = False
-            for constraint in constraints:
-                if isinstance(constraint, dict) and "verification" in constraint:
-                    constraint = {key: value for key, value in constraint.items() if key != "verification"}
-                    normalized = True
-                normalized_constraints.append(constraint)
-            if not normalized:
-                return response
-            normalized_payload = {**payload, "constraints": normalized_constraints}
-            try:
-                structured = self.schema.model_validate(normalized_payload)
-            except ValidationError:
-                return response
-            logger.warning("Discarded unsupported ResearchPlan constraint verification fields")
+            return response
         logger.info("Recovered %s from schema-valid JSON message content", self.schema.__name__)
         return ModelResponse(result=response.result, structured_response=structured)
 

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -46,6 +46,7 @@ from aiq_agent.common.citation_verification import is_non_citable_status_output
 from aiq_agent.common.logging_utils import log_content_metadata
 
 from .models import ResearchNotes
+from .models import ResearchPlan
 from .resource_limits import DeepResearchResourceLimits
 from .resource_limits import StateBudgetLedger
 
@@ -132,9 +133,32 @@ class StructuredResponseTextFallbackMiddleware(AgentMiddleware):
         if not isinstance(message, AIMessage) or message.tool_calls or not isinstance(message.content, str):
             return response
         try:
-            structured = self.schema.model_validate_json(message.content)
-        except ValidationError:
+            payload = json.loads(message.content)
+        except (TypeError, json.JSONDecodeError):
             return response
+        try:
+            structured = self.schema.model_validate(payload)
+        except ValidationError:
+            if self.schema is not ResearchPlan or not isinstance(payload, dict):
+                return response
+            constraints = payload.get("constraints")
+            if not isinstance(constraints, list):
+                return response
+            normalized_constraints = []
+            normalized = False
+            for constraint in constraints:
+                if isinstance(constraint, dict) and "verification" in constraint:
+                    constraint = {key: value for key, value in constraint.items() if key != "verification"}
+                    normalized = True
+                normalized_constraints.append(constraint)
+            if not normalized:
+                return response
+            normalized_payload = {**payload, "constraints": normalized_constraints}
+            try:
+                structured = self.schema.model_validate(normalized_payload)
+            except ValidationError:
+                return response
+            logger.warning("Discarded unsupported ResearchPlan constraint verification fields")
         logger.info("Recovered %s from schema-valid JSON message content", self.schema.__name__)
         return ModelResponse(result=response.result, structured_response=structured)
 

--- a/src/aiq_agent/agents/deep_researcher/models/subagent_contracts.py
+++ b/src/aiq_agent/agents/deep_researcher/models/subagent_contracts.py
@@ -83,6 +83,10 @@ class Constraint(_StrictContract):
     )
     constraint: str = Field(description="Specific, actionable constraint text.")
     rationale: str = Field(description="Why this constraint exists.")
+    verification: str | None = Field(
+        default=None,
+        description="Optional concrete check the writer can use to verify this constraint.",
+    )
 
 
 class SourceRecommendation(_StrictContract):

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -125,18 +125,15 @@ class TestStructuredResponseTextFallbackMiddleware:
             ],
         }
 
-    def test_normalizes_model_added_research_plan_verification_field(self, caplog) -> None:
+    def test_promotes_research_plan_with_constraint_verification(self) -> None:
         payload = self._research_plan()
         response = ModelResponse(result=[AIMessage(content=json.dumps(payload))])
         middleware = StructuredResponseTextFallbackMiddleware(ResearchPlan)
 
-        with caplog.at_level(logging.WARNING):
-            result = middleware._promote(response)
+        result = middleware._promote(response)
 
-        expected = json.loads(json.dumps(payload))
-        del expected["constraints"][0]["verification"]
-        assert result.structured_response == ResearchPlan.model_validate(expected)
-        assert "Discarded unsupported ResearchPlan constraint verification fields" in caplog.text
+        assert result.structured_response == ResearchPlan.model_validate(payload)
+        assert result.structured_response.constraints[0].verification == "Count two bullets"
 
     def test_promotes_exact_schema_valid_json_in_agent(self) -> None:
         payload = self._routing()

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -52,6 +52,7 @@ from aiq_agent.agents.deep_researcher.custom_middleware import TodoSuppressionMi
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolNameSanitizationMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolRetryMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolVisibilityMiddleware
+from aiq_agent.agents.deep_researcher.models import ResearchPlan
 from aiq_agent.agents.deep_researcher.models import SourceRoutingPlan
 from aiq_agent.agents.deep_researcher.resource_limits import DeepResearchResourceLimits
 from aiq_agent.agents.deep_researcher.resource_limits import StateBudgetLedger
@@ -82,6 +83,60 @@ class TestStructuredResponseTextFallbackMiddleware:
             "fallback_sources": [],
             "planner_guidance": "Use web search.",
         }
+
+    @staticmethod
+    def _research_plan() -> dict[str, object]:
+        return {
+            "task_analysis": {
+                "user_intent": "Compare networks",
+                "explicit_requirements": [],
+                "implicit_requirements": [],
+                "out_of_scope": [],
+                "language": "English",
+            },
+            "answer_strategy": {
+                "answer_type": "comparison",
+                "title": "Network comparison",
+                "required_components": [
+                    {
+                        "id": "comparison",
+                        "name": "Comparison",
+                        "description": "Compare the networks",
+                    }
+                ],
+            },
+            "constraints": [
+                {
+                    "category": "format",
+                    "constraint": "Return two bullets",
+                    "rationale": "Requested by the user",
+                    "verification": "Count two bullets",
+                }
+            ],
+            "queries": [
+                {
+                    "query": "Compare official specifications",
+                    "subqueries": [],
+                    "preferred_tools": ["advanced_web_search_tool"],
+                    "fallback_tools": [],
+                    "target_components": ["comparison"],
+                    "rationale": "Gather evidence",
+                }
+            ],
+        }
+
+    def test_normalizes_model_added_research_plan_verification_field(self, caplog) -> None:
+        payload = self._research_plan()
+        response = ModelResponse(result=[AIMessage(content=json.dumps(payload))])
+        middleware = StructuredResponseTextFallbackMiddleware(ResearchPlan)
+
+        with caplog.at_level(logging.WARNING):
+            result = middleware._promote(response)
+
+        expected = json.loads(json.dumps(payload))
+        del expected["constraints"][0]["verification"]
+        assert result.structured_response == ResearchPlan.model_validate(expected)
+        assert "Discarded unsupported ResearchPlan constraint verification fields" in caplog.text
 
     def test_promotes_exact_schema_valid_json_in_agent(self) -> None:
         payload = self._routing()


### PR DESCRIPTION
## Summary
- add an optional `Constraint.verification` field to the structured `ResearchPlan` contract
- preserve planner-generated checks for the writer instead of rejecting or discarding them
- retain the normal one-retry structured-response fallback behavior for provider responses returned as JSON text

## Validation
- `uv run pytest tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py -k StructuredResponseTextFallbackMiddleware -q` (11 passed)
- `uv run ruff check src/aiq_agent/agents/deep_researcher/models/subagent_contracts.py src/aiq_agent/agents/deep_researcher/custom_middleware.py tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py`

Observed incident signature: planner retries exhausted after otherwise-valid `ResearchPlan` payloads added one `verification` check to every constraint (six fields in the original capture; seven in the live reproduction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Research constraints can now include an optional verification instruction to support concrete checks.
  - Structured research plans accept valid JSON content and preserve supported verification details.

- **Bug Fixes**
  - Improved recovery and validation of structured research-plan responses.
  - Unsupported fields are safely discarded, while invalid or unrecognized responses remain rejected.

- **Tests**
  - Added coverage for JSON normalization, schema validation, supported-field preservation, and unsupported-field removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->