### PR TITLE
fix: align NRL shallow config defaults

### DIFF
--- a/configs/config_web_nemo_retriever.yml
+++ b/configs/config_web_nemo_retriever.yml
@@ -65,7 +65,7 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     temperature: 0.2
     top_p: 0.7
-    max_tokens: 8192
+    max_tokens: 32768
     num_retries: 5
     parallel_tool_calls: false
     chat_template_kwargs:
@@ -192,6 +192,7 @@ functions:
     verbose: true
     max_llm_turns: 10
     max_tool_iterations: 5
+    enforce_citations: false
 
   deep_research_agent:
     _type: deep_research_agent

--- a/configs/config_web_nemo_retriever_local.yml
+++ b/configs/config_web_nemo_retriever_local.yml
@@ -40,7 +40,7 @@ llms:
     base_url: ${AIQ_AGENT_LLM_BASE_URL:-http://127.0.0.1:1234/v1}
     api_key: ${AIQ_AGENT_LLM_API_KEY:-local}
     temperature: 0.2
-    max_tokens: 16384
+    max_tokens: 32768
     num_retries: 3
 
 functions:
@@ -116,6 +116,7 @@ functions:
     verbose: true
     max_llm_turns: 10
     max_tool_iterations: 5
+    enforce_citations: false
 
   deep_research_agent:
     _type: deep_research_agent

--- a/tests/knowledge_layer_tests/test_nemo_retriever_local_adapter.py
+++ b/tests/knowledge_layer_tests/test_nemo_retriever_local_adapter.py
@@ -525,6 +525,7 @@ def test_local_profile_selects_embedded_backend_and_upstream_auto_defaults() -> 
     assert local_llm["model_name"] == "${AIQ_AGENT_LLM_MODEL:-openai/local-tool-model}"
     assert local_llm["base_url"] == "${AIQ_AGENT_LLM_BASE_URL:-http://127.0.0.1:1234/v1}"
     assert local_llm["api_key"] == "${AIQ_AGENT_LLM_API_KEY:-local}"
+    assert local_llm["max_tokens"] == 32768
     assert "parallel_tool_calls" not in local_llm
     for function in functions.values():
         if not isinstance(function, dict):
@@ -556,6 +557,16 @@ def test_nemo_retriever_profiles_only_keep_supported_verbose_setting() -> None:
         assert functions["shallow_research_agent"]["verbose"] is True
         assert "verbose" not in functions["deep_research_agent"]
         assert "verbose" not in config["workflow"]
+
+
+def test_nemo_retriever_shallow_profiles_pin_citation_policy() -> None:
+    for filename in ("config_web_nemo_retriever.yml", "config_web_nemo_retriever_local.yml"):
+        config = yaml.safe_load((PROJECT_ROOT / "configs" / filename).read_text(encoding="utf-8"))
+        shallow_agent = config["functions"]["shallow_research_agent"]
+
+        assert shallow_agent["max_llm_turns"] == 10
+        assert shallow_agent["max_tool_iterations"] == 5
+        assert shallow_agent["enforce_citations"] is False
 
 
 def test_pdf_image_extraction_supports_pdfium_4_and_5(tmp_path) -> None:

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -17,6 +17,7 @@ CONFIG_PATHS = [
     REPO_ROOT / "configs" / "config_web_default_llamaindex.yml",
     REPO_ROOT / "configs" / "config_web_frag.yml",
     REPO_ROOT / "configs" / "config_web_frag_mcp_auth.yml",
+    REPO_ROOT / "configs" / "config_web_nemo_retriever.yml",
     REPO_ROOT / "configs" / "config_web_opensearch.yml",
     REPO_ROOT / "configs" / "nemo_relay" / "config_web_default_with_pricing.yml",
     REPO_ROOT / ".agents" / "skills" / "aiq-configure-workflow" / "assets" / "config-scaffold.yml",


### PR DESCRIPTION
## Summary
- align external NeMo Retriever shallow profile with the 32768 Lightning agent max-token default
- align embedded/local NeMo Retriever agent LLM max tokens to 32768
- explicitly set shallow_research_agent enforce_citations: false in both NRL configs
- add config tests to keep NRL max-token and citation policy defaults pinned

## Tests
- UV_CACHE_DIR=/tmp/aiq-uv-cache uv run pytest tests/test_config_defaults.py tests/knowledge_layer_tests/test_nemo_retriever_local_adapter.py -k 'test_lightning_agent_llm_uses_full_output_cap or test_local_profile_selects_embedded_backend_and_upstream_auto_defaults or test_nemo_retriever_profiles_only_keep_supported_verbose_setting or test_nemo_retriever_shallow_profiles_pin_citation_policy'
- UV_CACHE_DIR=/tmp/aiq-uv-cache uv run ruff check tests/test_config_defaults.py tests/knowledge_layer_tests/test_nemo_retriever_local_adapter.py

Note: local commit hooks passed except markdown-link-check was skipped because the local Node/npm versions are incompatible; no Markdown files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum response length for standard and local web research to support longer results.
  * Updated shallow research to operate without mandatory citations.

* **Tests**
  * Added coverage to verify response limits, shallow research settings, and configuration defaults across web research modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->