### PR TITLE
feat: enable and reliably render inline charts in deep and shallow research

### DIFF
--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -209,6 +209,11 @@ functions:
     max_llm_turns: 10
     max_tool_iterations: 5
 
+  deep_research_skills:
+    _type: deep_research_skills
+    agents:
+      writer-agent: [visualization]
+
   deep_research_agent:
     _type: deep_research_agent
     enable_citation_verification: true
@@ -220,6 +225,7 @@ functions:
     # tools: omitted -> inherits all from data_source_registry
     exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool
       - web_search_tool
+    skills: deep_research_skills
 
 workflow:
   _type: chat_deepresearcher_agent

--- a/frontends/ui/src/shared/components/ResultChart/parse.spec.ts
+++ b/frontends/ui/src/shared/components/ResultChart/parse.spec.ts
@@ -16,6 +16,14 @@ const barSpec = {
   ],
 }
 const lineSpec = { ...barSpec, type: 'line' }
+const singleKeyRowSpec = {
+  type: 'hbar',
+  title: 'FY2025 Data Center Revenue Comparison',
+  x: { key: 'revenue', label: 'Revenue (USD billions)' },
+  y: { label: 'Company' },
+  series: [{ key: 'revenue', color: 'green' }],
+  data: [{ NVIDIA: 115.3 }, { AMD: 12.6 }, { Intel: 9.1 }],
+}
 
 describe('toNumber', () => {
   test('numbers pass through, non-finite becomes null', () => {
@@ -81,6 +89,53 @@ describe('parseChartSpec', () => {
     }
     expect(parseChartSpec(JSON.stringify(spec))).toBeNull()
   })
+
+  test('repairs a single-key-row spec into a renderable chart', () => {
+    const spec = parseChartSpec(JSON.stringify(singleKeyRowSpec))
+    expect(spec).not.toBeNull()
+    if (!spec) return
+    expect(spec.data).toHaveLength(3)
+    expect(spec.data.every((row) => row[spec.x.key] != null && row[spec.x.key] !== '')).toBe(true)
+    expect(spec.series).toHaveLength(1)
+    expect(spec.data.map((row) => toNumber(row[spec.series[0].key]))).toEqual([115.3, 12.6, 9.1])
+    expect(spec.series[0].color).toBe('green')
+  })
+
+  test('single keys that match a declared field or repeat stay un-repairable', () => {
+    const base = { ...singleKeyRowSpec, x: { key: 'company' }, series: [{ key: 'revenue', color: 'green' }] }
+    const fieldNameKeyed = { ...base, data: [{ revenue: 115.3 }, { revenue: 12.6 }, { revenue: 9.1 }] }
+    expect(parseChartSpec(JSON.stringify(fieldNameKeyed))).toBeNull()
+    const repeatedLabel = { ...base, data: [{ Acme: 1 }, { Acme: 2 }] }
+    expect(parseChartSpec(JSON.stringify(repeatedLabel))).toBeNull()
+  })
+
+  test('multi-series single-key-row specs stay un-repairable', () => {
+    const multiSeries = {
+      ...singleKeyRowSpec,
+      x: { key: 'company' },
+      series: [
+        { key: 'q1', color: 'green' },
+        { key: 'q2', color: 'blue' },
+      ],
+      data: [{ NVIDIA: 115.3 }, { AMD: 12.6 }, { Intel: 9.1 }],
+    }
+    expect(parseChartSpec(JSON.stringify(multiSeries))).toBeNull()
+  })
+
+  test('a well-formed spec is not altered by the repair fallback', () => {
+    expect(parseChartSpec(JSON.stringify(barSpec))).toEqual(ChartSpecSchema.parse(barSpec))
+  })
+
+  test('rows with multiple keys and no matching x key stay un-repairable', () => {
+    const spec = { ...barSpec, x: { key: 'missing' } }
+    expect(parseChartSpec(JSON.stringify(spec))).toBeNull()
+  })
+
+  test('carousel and kpi parsing are unaffected by the repair fallback', () => {
+    const carousel = { title: 'Trends', charts: [lineSpec, lineSpec] }
+    expect(parseCarouselSpec(JSON.stringify(carousel))?.charts).toHaveLength(2)
+    expect(parseKpiSpec(JSON.stringify({ kpis: [{ label: 'A', value: '1' }] }))?.kpis).toHaveLength(1)
+  })
 })
 
 describe('ChartSpecSchema delta refinement', () => {
@@ -109,6 +164,16 @@ describe('parseCarouselSpec', () => {
     const badChild = { ...lineSpec, x: { key: 'missing' } }
     const spec = { title: 'Trends', charts: [lineSpec, badChild] }
     expect(parseCarouselSpec(JSON.stringify(spec))).toBeNull()
+  })
+
+  test('repairs a single-key-row child so the carousel renders it', () => {
+    const singleKeyLine = { ...singleKeyRowSpec, type: 'line' }
+    const spec = { title: 'Trends', charts: [lineSpec, singleKeyLine] }
+    const parsed = parseCarouselSpec(JSON.stringify(spec))
+    expect(parsed?.charts).toHaveLength(2)
+    const repaired = parsed?.charts[1]
+    expect(repaired?.x.key).toBe('category')
+    expect(repaired?.data.every((row) => row['category'] != null && toNumber(row['value']) != null)).toBe(true)
   })
 })
 

--- a/frontends/ui/src/shared/components/ResultChart/parse.ts
+++ b/frontends/ui/src/shared/components/ResultChart/parse.ts
@@ -6,6 +6,7 @@ import {
   ChartSpecSchema,
   KpiOnlySpecSchema,
   type ChartCarouselSpec,
+  type ChartSeries,
   type ChartSpec,
   type KpiOnlySpec,
 } from './types'
@@ -38,23 +39,68 @@ export function toNumber(value: unknown): number | null {
 }
 
 /**
+ * Whether a schema-valid spec has something meaningful to draw: the x key must
+ * resolve on at least one row, and every series must carry at least one numeric
+ * value (via {@link toNumber}).
+ */
+function isRenderable(spec: ChartSpec): boolean {
+  const hasX = spec.data.some((row) => row[spec.x.key] != null && row[spec.x.key] !== '')
+  if (!hasX) return false
+  return spec.series.every((s) => spec.data.some((row) => toNumber(row[s.key]) != null))
+}
+
+/**
+ * Deterministic repair for the shape weaker models sometimes emit, where each row
+ * carries the category value as its object key (e.g. `{"NVIDIA":115.3}`) instead
+ * of flat fields, so no key resolves. Applies only when every row is an object
+ * with exactly one key whose value coerces to a number: it rewrites x.key to
+ * "category", collapses to a single "value" series (preserving the first series'
+ * color and label), and rebuilds each row as `{ category: <label>, value: <num> }`.
+ * The repair is skipped (returns null, so the block falls back to raw JSON) for a
+ * multi-series spec (this shape carries one value per row, so collapsing it would
+ * hide the other declared series), or when a row key matches a declared field name
+ * (x or a series key) or repeats across rows, since those indicate a different
+ * broken spec that would otherwise become mislabeled or duplicated categories
+ * rather than the intended category-as-key shape.
+ */
+function repairSingleKeyRows(spec: ChartSpec): ChartSpec | null {
+  if (spec.series.length !== 1) return null
+  const declaredKeys = new Set([spec.x.key, ...spec.series.map((s) => s.key)])
+  const seenLabels = new Set<string>()
+  const data: ChartSpec['data'] = []
+  for (const row of spec.data) {
+    const keys = Object.keys(row)
+    if (keys.length !== 1) return null
+    const label = keys[0]
+    if (declaredKeys.has(label) || seenLabels.has(label)) return null
+    const value = toNumber(row[label])
+    if (value == null) return null
+    seenLabels.add(label)
+    data.push({ category: label, value })
+  }
+  const source = spec.series[0]
+  const series: ChartSeries = { key: 'value' }
+  if (source.label) series.label = source.label
+  if (source.color) series.color = source.color
+  return { ...spec, x: { ...spec.x, key: 'category' }, series: [series], data }
+}
+
+/**
  * Parse + validate a ```chart block's JSON into a {@link ChartSpec}. Returns null
  * (so the caller can fall back to the raw block) when the JSON is malformed, fails
- * the schema, or references keys with no usable data.
+ * the schema, or references keys with no usable data. A schema-valid spec whose
+ * keys do not resolve is given one deterministic repair pass for the single-key
+ * row shape before giving up.
  */
 export function parseChartSpec(raw: string): ChartSpec | null {
   const parsed = ChartSpecSchema.safeParse(parseJson(raw))
   if (!parsed.success) return null
   const spec = parsed.data
 
-  // The x key must resolve on at least one row, and every series must carry at
-  // least one numeric value, otherwise there is nothing meaningful to draw.
-  const hasX = spec.data.some((row) => row[spec.x.key] != null && row[spec.x.key] !== '')
-  if (!hasX) return null
-  const everySeriesNumeric = spec.series.every((s) => spec.data.some((row) => toNumber(row[s.key]) != null))
-  if (!everySeriesNumeric) return null
+  if (isRenderable(spec)) return spec
 
-  return spec
+  const repaired = repairSingleKeyRows(spec)
+  return repaired && isRenderable(repaired) ? repaired : null
 }
 
 /** Parse + validate a ```chart-carousel block of related line charts. */
@@ -62,10 +108,13 @@ export function parseCarouselSpec(raw: string): ChartCarouselSpec | null {
   const parsed = ChartCarouselSpecSchema.safeParse(parseJson(raw))
   if (!parsed.success) return null
 
+  const charts: ChartCarouselSpec['charts'] = []
   for (const chart of parsed.data.charts) {
-    if (!parseChartSpec(JSON.stringify(chart))) return null
+    const renderable = parseChartSpec(JSON.stringify(chart))
+    if (!renderable) return null
+    charts.push(renderable as ChartCarouselSpec['charts'][number])
   }
-  return parsed.data
+  return { ...parsed.data, charts }
 }
 
 /**

--- a/src/aiq_agent/agents/deep_researcher/skills/visualization/chart-generation/SKILL.md
+++ b/src/aiq_agent/agents/deep_researcher/skills/visualization/chart-generation/SKILL.md
@@ -233,7 +233,10 @@ row>", "label": "optional" }`; optional `y` = `{ "label": "optional unit", "form
 compact | percent | currency" }`; `series` = `[ { "key": "<numeric field>", "label": "optional",
 "color": "green | blue | amber | red" } ]`; `data` = rows as objects with raw numbers (fractions
 0-1 for `percent`); optional `kpis` = `[ { "label": "...", "value": "preformatted", "tone": "accent
-| warn | alarm" } ]`. A `delta` chart encodes exactly one series.
+| warn | alarm" } ]`. A `delta` chart encodes exactly one series. Each data row is one
+flat object that includes the `x` key and every series key as fields (for example
+`{"company":"NVIDIA","revenue":115.3}`); never use the category value itself as the key
+(not `{"NVIDIA":115.3}`), and never reuse the same key for `x` and a series.
 
 Example (ranking):
 

--- a/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
@@ -55,6 +55,8 @@ Chart types: `bar` (category magnitudes), `hbar` (rankings with long text labels
 
 Spec fields: `type`; `title` (short) and optional `subtitle`; `x` = `{ "key": "<field in each row>", "label": "optional" }`; optional `y` = `{ "label": "optional unit", "format": "number | compact | percent | currency" }`; `series` = `[ { "key": "<numeric field>", "label": "optional", "color": "green | blue | amber | red" } ]`; `data` = rows as objects with raw numbers (fractions 0-1 for `percent`); optional `kpis` = `[ { "label": "...", "value": "preformatted", "tone": "accent | warn | alarm" } ]`.
 
+Each data row is one flat object that includes the `x` key and every series key as fields (for example `{"company":"NVIDIA","revenue":115.3}`); never use the category value itself as the key (not `{"NVIDIA":115.3}`), and never reuse the same key for `x` and a series.
+
 Example (ranking):
 ```chart
 {"type":"hbar","title":"Top suppliers by late shipments","x":{"key":"supplier"},"y":{"format":"number"},"series":[{"key":"late","color":"amber"}],"data":[{"supplier":"Acme","late":42},{"supplier":"Globex","late":31},{"supplier":"Initech","late":19}]}


### PR DESCRIPTION
#### Overview

Makes charts appear in chat for both research paths.

- **Deep research (the gap):** the deployed config wired the deep-research `writer-agent` to its LLM but never assigned it the chart skill, so deep reports never rendered charts. Enable it (config only).
- **Shallow research:** already emits inline charts from its prompt (only when the data is comparable), so no behavior change there. But weaker chat models occasionally emit a malformed chart shape that the renderer rejected, so charts intermittently fell back to raw JSON. Repair that shape at render time and clarify it in the prompts.

#### Changes

**1. Enable the deep-research chart skill (config only)**
- Add a `deep_research_skills` function (`writer-agent: [visualization]`) and `skills: deep_research_skills` on `deep_research_agent` in `config_web_default_llamaindex.yml`.
- No sandbox: the `chart-generation` skill uses inline mode with no `execute` tool and emits a fenced ```chart spec the UI already renders. Zero new infrastructure; the sandbox-required `research` skill stays off.

**2. Render inline charts reliably (frontend + prompt)**
- `ResultChart/parse.ts`: when a schema-valid spec's keys do not resolve, run one deterministic repair for the common weak-model shape where each row carries the category value as its key (for example `{"NVIDIA":115.3}`), rewriting rows to `{ category, value }`. The strict path is unchanged for well-formed specs.
- Add a data-row shape line to `shallow_researcher/prompts/researcher.j2` and the deep `chart-generation/SKILL.md` to reduce the malformed shape at the source.

#### Validation

Backend config:
- `nat validate` -> valid; the `skills` ref resolves and the no-sandbox build passes `_validate_sandbox_requirements`.
- Runtime: `writer-agent: [visualization]` resolves the `chart-generation` skill (`agent_has_chart_skill` is true).

End-to-end (real agent pipeline, gateway LLMs, live chart path; web search served canned data):

| Path | Skill | Query | Result |
| :-- | :-- | :-- | :-- |
| deep | on | comparative | renders a chart |
| deep | off (control) | comparative | table only, no chart |
| shallow | n/a | comparative | renders a chart |
| shallow | n/a | plain text | no chart (only when needed) |

Frontend:
- `ResultChart` + `MarkdownRenderer` suites: 194 tests pass (incl. new repair tests: malformed shape now renders, valid specs unchanged, unrepairable specs stay null).
- `npm run type-check`, `npm run lint` (0 errors), `npm run build` all pass.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s`.

#### Where should reviewers start?

- `configs/config_web_default_llamaindex.yml` for the deep-chart enablement.
- `frontends/ui/src/shared/components/ResultChart/parse.ts` for the render-time repair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved chart handling so valid single-key-row data can be repaired and rendered reliably.
  - Updated carousel charts to use validated or repaired chart results.
  - Enabled visualization capabilities for deep research outputs.

- **Bug Fixes**
  - Prevented malformed chart specifications from causing rendering issues while preserving valid and unrecoverable data.

- **Documentation**
  - Clarified chart data requirements for consistent axis and series rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->