### PR TITLE
docs: add third-party Fly.io Sprites sandbox provider

### DIFF
--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -12,7 +12,8 @@ Skills let a research agent discover task-specific instructions only when they a
 skill definitions read-only from the host. A skill can teach the agent a repeatable workflow, such as extracting numeric
 facts, normalizing a table, running calculations, and producing reusable text artifacts. When a skill invokes
 `execute`, the generated code runs outside the AI-Q process in one provider sandbox per deep-research job. Modal and
-OpenShell implement this job-scoped contract.
+OpenShell implement this job-scoped contract. Third-party packages can implement the same contract through AI-Q's
+`aiq.sandbox_providers` entry point.
 
 For more background, refer to the LangChain DeepAgents docs:
 
@@ -120,6 +121,46 @@ sandbox per job, verifies the effective policy and revision before use, and
 deletes the sandbox at terminal cleanup. Attaching to an existing shared
 sandbox is available only through explicit debug settings and is not
 job-isolated.
+
+### Use the third-party Sprites provider
+
+[Fly.io's Sprites provider](https://github.com/superfly/aiq-sandbox-sprites) is an external package that implements
+AI-Q's sandbox-provider entry point. Install it into the same environment as AI-Q and provide a restricted Sprites
+token to the host process:
+
+```bash
+.venv/bin/python -m pip install aiq-sandbox-sprites
+export SPRITE_TOKEN="..."  # pragma: allowlist secret
+```
+
+Select the external provider with the standard sandbox configuration surface:
+
+```yaml
+functions:
+  deep_research_sandbox:
+    _type: deep_research_sandbox
+    provider: sprites
+    workdir: /workspace
+    packages:
+      - matplotlib
+      - numpy
+      - pandas
+      - pillow
+      - tabulate
+    network: blocked
+    timeout: 1200
+    idle_timeout: 1800
+    artifact_capture:
+      enabled: true
+      max_file_bytes: 50000000
+      allow_extensions: [.png, .jpg, .jpeg, .webp, .csv, .json, .md, .ipynb, .pdf]
+```
+
+The host-side provider creates one ownership-labeled Sprite per job, installs the trusted package list before applying
+the requested network policy, and removes the Sprite during normal or interrupted AI-Q cleanup. The token remains in
+the host process and is not copied into the Sprite. CPU and memory limits are not currently supported through this
+provider, and production operators still need an external orphan reaper for complete worker-host loss. Refer to the
+provider repository for its supported AI-Q versions, environment-specific settings, tests, and security details.
 
 ## Run Synchronously with `nat run` (Non-Persistent)
 

--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -124,8 +124,8 @@ job-isolated.
 ### Use the third-party Sprites provider
 
 [Fly.io's Sprites provider](https://github.com/superfly/aiq-sandbox-sprites) is an external package that implements
-AI-Q's sandbox-provider entry point. Install it into the same environment as AI-Q and provide a restricted Sprites
-token to the host process:
+AI-Q's sandbox-provider entry point. It requires AI-Q 2.2, does not support AI-Q 2.1, and has been tested with AI-Q
+v2.2.1. Install it into the same environment as AI-Q and provide a restricted Sprites token to the host process:
 
 ```bash
 .venv/bin/python -m pip install aiq-sandbox-sprites

--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -12,8 +12,7 @@ Skills let a research agent discover task-specific instructions only when they a
 skill definitions read-only from the host. A skill can teach the agent a repeatable workflow, such as extracting numeric
 facts, normalizing a table, running calculations, and producing reusable text artifacts. When a skill invokes
 `execute`, the generated code runs outside the AI-Q process in one provider sandbox per deep-research job. Modal and
-OpenShell implement this job-scoped contract. Third-party packages can implement the same contract through AI-Q's
-`aiq.sandbox_providers` entry point.
+OpenShell implement this job-scoped contract.
 
 For more background, refer to the LangChain DeepAgents docs:
 

--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -51,7 +51,8 @@ export NVIDIA_API_KEY="nvapi-..."              # pragma: allowlist secret
 export TAVILY_API_KEY="tvly-..."               # pragma: allowlist secret
 ```
 
-For sandbox execution, create a Modal account and configure Modal credentials. Modal uses a token ID and token secret:
+When using `provider: modal`, create a Modal account and configure Modal credentials. Modal uses a token ID and token
+secret:
 
 ```bash
 export MODAL_TOKEN_ID="ak-..."                 # pragma: allowlist secret
@@ -65,6 +66,7 @@ modal token set --token-id "$MODAL_TOKEN_ID" --token-secret "$MODAL_TOKEN_SECRET
 ```
 
 Refer to Modal's token configuration docs for details: [modal.config](https://modal.com/docs/reference/modal.config).
+Other sandbox providers use their own credentials; `provider: sprites` requires `SPRITE_TOKEN` as described below.
 
 ## Configuration
 


### PR DESCRIPTION
#### Overview

Document Fly.io's external Sprites sandbox provider for AI-Q deep-research jobs.

The new section explains how AI-Q discovers the provider through its existing
`aiq.sandbox_providers` entry point, how to install and select it, which standard
sandbox settings it accepts, how the host credential is isolated, and the
current resource-limit and orphan-cleanup constraints. The provider remains an
out-of-tree package maintained by Fly.io.

#### DCO sign-off for the squash commit

Signed-off-by: Matt Pearce <mattp@fly.io>

#### Validation

- `PATH=../.venv/bin:$PATH make html` from `docs/`
  - Sphinx 9.1.0 completed successfully.
  - Two pre-existing `mcp/SECURITY` cross-reference warnings remain unrelated to this page.
- `.venv/bin/pre-commit run --files docs/source/examples/skills-sandbox/index.md`
  - Merge-conflict, large-file, whitespace, secret, and Markdown link checks passed.
- Provider release CI: https://github.com/superfly/aiq-sandbox-sprites/actions/runs/33354008706
  - Python 3.11, 3.12, and 3.13 tests and package validation passed.
- The built provider wheel passed dependency checks and both normal and interrupted
  artifact/lifecycle scenarios against AI-Q v2.2.1 with its locked DeepAgents 0.6.8.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with the new "Use the third-party Sprites provider" section in
`docs/source/examples/skills-sandbox/index.md`. The key review decision is whether
the existing provider-neutral example page is the right discovery point for an
out-of-tree provider.

#### Related Issues

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Modal is the default provider prerequisite for the skills sandbox.
  * Added credential guidance for configuring non-Modal providers.
  * Documented Fly.io Sprites integration, including installation, AI-Q 2.2 compatibility, token setup, provider configuration, per-job sandbox lifecycle, cleanup, token isolation, unsupported resource limits, and orphaned sandbox reaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->