### PR TITLE
fix(citation): normalize query-parameter key casing in _normalize_url

### DIFF
--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -250,7 +250,8 @@ def _normalize_url(url: str) -> str:
     path = unquote(parsed.path).rstrip("/") or "/"
     # Remove tracking params
     qs = parse_qs(parsed.query, keep_blank_values=True)
-    filtered_qs = {k: v for k, v in qs.items() if k.lower() not in _TRACKING_PARAMS}
+    # Exclusion below is case-insensitive, so the rebuilt key must be too.
+    filtered_qs = {k.lower(): v for k, v in qs.items() if k.lower() not in _TRACKING_PARAMS}
     query_str = "&".join(f"{k}={v[0]}" for k, v in sorted(filtered_qs.items()) if v)
     return urlunparse((scheme, netloc, path, "", query_str, ""))
 

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -150,6 +150,12 @@ class TestNormalizeUrl:
         url2 = "https://example.com/article?id=42"
         assert _normalize_url(url1) == _normalize_url(url2)
 
+    def test_query_param_key_casing_normalized(self):
+        """Query parameter name casing must not affect the comparison key."""
+        assert _normalize_url("https://example.com/article?ID=42") == _normalize_url(
+            "https://example.com/article?id=42"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Citation key parsing tests
@@ -389,6 +395,11 @@ class TestSourceRegistry:
         registry.add(SourceEntry(url="https://example.com/doc?id=123&mode=view"))
         # The path-only URL is a prefix of the full normalized URL → prefix match succeeds
         assert registry.resolve_url("https://example.com/doc") == "https://example.com/doc?id=123&mode=view"
+
+    def test_resolve_url_query_key_casing(self, registry):
+        """A re-cased query param name must still resolve."""
+        registry.add(SourceEntry(url="https://example.com/article?ID=42"))
+        assert registry.resolve_url("https://example.com/article?id=42") == "https://example.com/article?ID=42"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`_normalize_url` excludes tracking params case-insensitively (`k.lower() not in _TRACKING_PARAMS`) but rebuilds the comparison string from the original key casing, so `?ID=42` and `?id=42` normalize differently and `SourceRegistry.resolve_url` silently fails to match. `sorted()` runs on the original case too, so `?B=1&a=2` and `?b=1&a=2` order differently.

One line: lowercase the key when building `filtered_qs`, matching the exclusion check above it.

Two tests, failing before and passing after: 2 failed / 166 passed before, 168 passed after.

Worth flagging: this makes two params differing only in key case collide, which is wrong for a server that treats them as distinct. The module already assumes case-insensitivity for tracking-param exclusion, so I made it consistent, but the inverse fix (make the exclusion case-sensitive) is equally defensible and your call.

Could not verify: `uv sync --group dev` does not complete on Windows here (`oci` wheel extraction, OS error 1450, unrelated to this change), so I could not run your documented `uv run pytest`. I ran the real module unmodified via importlib with the heavy `aiq_agent.common.__init__` chain stubbed, which executes the actual production code; all 166 pre-existing tests in the file pass unchanged under that harness. `ruff check` and `ruff format --diff` clean on both files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - URL normalization now treats query parameter names case-insensitively when excluding tracking parameters.
  - URLs that differ only in query-key casing are now recognized as equivalent and resolve consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->